### PR TITLE
fix: Press enter key send values.

### DIFF
--- a/components/ADempiere/Field/mixin/mixinField.js
+++ b/components/ADempiere/Field/mixin/mixinField.js
@@ -240,7 +240,7 @@ export default {
     },
     /**
      * Keyup enter event on DOM element, call this method
-     * @param {objet} event html
+     * @param {object} event html
      */
     actionKeyPerformed(event) {
       if (this.metadata.handleActionKeyPerformed) {

--- a/components/ADempiere/Field/mixin/mixinField.js
+++ b/components/ADempiere/Field/mixin/mixinField.js
@@ -238,15 +238,21 @@ export default {
         })
       }
     },
-    actionKeyPerformed(value) {
+    /**
+     * Keyup enter event on DOM element, call this method
+     * @param {objet} event html
+     */
+    actionKeyPerformed(event) {
       if (this.metadata.handleActionKeyPerformed) {
         this.$store.dispatch('notifyActionKeyPerformed', {
           containerUuid: this.metadata.containerUuid,
           columnName: this.metadata.columnName,
-          value: value.target.value,
-          keyCode: value.keyCode
+          value: event.target.value,
+          keyCode: event.keyCode
         })
       }
+      // enter key sends the values
+      this.preHandleChange(event.target.value)
     },
     keyReleased(value) {
       if (this.metadata.handleKeyReleased) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Product Group` window.
2. Create New.
3. Modify the value field.
4. Press Enter: Note that the validation message is showed.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/161968295-5363c5d6-8f63-41bf-a282-056214955e35.mp4

#### Expected behavior
When enter is pressed it should trigger a request foe validate and save

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 100.0
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.
