### PR TITLE
feat: Refactor props components fields.

### DIFF
--- a/components/ADempiere/Field/FieldAutocomplete.vue
+++ b/components/ADempiere/Field/FieldAutocomplete.vue
@@ -15,10 +15,11 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https:www.gnu.org/licenses/>.
 -->
+
 <template>
   <el-autocomplete
     v-model="displayedValue"
-    :placeholder="metadata.placeholder"
+    v-bind="commonsProperties"
     :fetch-suggestions="localSearch"
     :trigger-on-focus="true"
     clearable
@@ -53,7 +54,7 @@
 </template>
 
 <script>
-// mixins
+// components and mixins
 import fieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
 import selectMixin from '@theme/components/ADempiere/Field/mixin/mixinFieldSelect.js'
 

--- a/components/ADempiere/Field/FieldBinary.vue
+++ b/components/ADempiere/Field/FieldBinary.vue
@@ -15,17 +15,16 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https:www.gnu.org/licenses/>.
 -->
+
 <template>
   <el-upload
-    :ref="metadata.columnName"
     v-model="value"
+    v-bind="commonsProperties"
     :limit="metadata.Limit"
     :on-remove="handleRemove"
     :on-success="handleSuccess"
     :on-error="handleError"
-    :class="cssClassStyle"
     action="https://jsonplaceholder.typicode.com/posts/"
-    :disabled="isDisabled"
     @change="preHandleChange"
   >
     <el-button size="small" type="primary">
@@ -38,11 +37,16 @@
 </template>
 
 <script>
+// components and mixins
 import fieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
 
 export default {
   name: 'FieldBinary',
-  mixins: [fieldMixin],
+
+  mixins: [
+    fieldMixin
+  ],
+
   computed: {
     cssClassStyle() {
       let styleClass = ' image-uploader '
@@ -52,6 +56,7 @@ export default {
       return styleClass
     }
   },
+
   methods: {
     handleRemove(file) {
       this.$message.success(`The previously uploaded file has been deleted.`)

--- a/components/ADempiere/Field/FieldButton.vue
+++ b/components/ADempiere/Field/FieldButton.vue
@@ -17,19 +17,21 @@
 -->
 <template>
   <el-input
-    :ref="metadata.columnName"
     v-model="value"
+    v-bind="commonsProperties"
     type="hidden"
     @change="preHandleChange"
   />
 </template>
 
 <script>
+// components and mixins
 import fieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
 import fieldMixinText from '@theme/components/ADempiere/Field/mixin/mixinFieldText.js'
 
 export default {
   name: 'FieldButton',
+
   mixins: [
     fieldMixin,
     fieldMixinText

--- a/components/ADempiere/Field/FieldColor.vue
+++ b/components/ADempiere/Field/FieldColor.vue
@@ -15,23 +15,24 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https:www.gnu.org/licenses/>.
 -->
+
 <template>
   <el-color-picker
-    :ref="metadata.columnName"
     v-model="value"
+    v-bind="commonsProperties"
     show-alpha
-    :disabled="isDisabled"
-    :class="cssClassStyle"
     @change="preHandleChange"
   />
 </template>
 
 <script>
+// components and mixins
 import fieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
 import fieldMixinText from '@theme/components/ADempiere/Field/mixin/mixinFieldText.js'
 
 export default {
   name: 'FieldColor',
+
   mixins: [
     fieldMixin,
     fieldMixinText

--- a/components/ADempiere/Field/FieldDate.vue
+++ b/components/ADempiere/Field/FieldDate.vue
@@ -18,19 +18,15 @@
 
 <template>
   <el-date-picker
-    :ref="metadata.columnName"
     v-model="value"
+    v-bind="commonsProperties"
     :format="formatView"
     :value-format="formatSend"
     :type="typePicker"
     range-separator="-"
-    :placeholder="metadata.placeholder"
     :start-placeholder="$t('components.dateStartPlaceholder')"
     :end-placeholder="$t('components.dateEndPlaceholder')"
     unlink-panels
-    :class="cssClassStyle"
-    :readonly="Boolean(metadata.readonly)"
-    :disabled="isDisabled"
     :picker-options="pickerOptions"
     @change="preHandleChange"
     @blur="focusLost"
@@ -42,7 +38,7 @@
 
 <script>
 // components and mixins
-import FieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
+import fieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
 
 // constants
 import { DATE_PLUS_TIME } from '@/utils/ADempiere/references'
@@ -55,7 +51,7 @@ export default {
   name: 'FieldDate',
 
   mixins: [
-    FieldMixin
+    fieldMixin
   ],
 
   data() {

--- a/components/ADempiere/Field/FieldImage.vue
+++ b/components/ADempiere/Field/FieldImage.vue
@@ -15,16 +15,15 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https:www.gnu.org/licenses/>.
 -->
+
 <template>
   <el-upload
-    :ref="metadata.columnName"
+    v-bind="commonsProperties"
     action="https://jsonplaceholder.typicode.com/posts/"
     :show-file-list="false"
     :on-success="handleAvatarSuccess"
     :on-change="handleChange"
     :before-upload="beforeAvatarUpload"
-    :disabled="isDisabled"
-    :class="cssClassStyle"
   >
     <img v-if="value" :src="value" class="avatar">
     <i v-else class="el-icon-plus avatar-uploader-icon" />
@@ -32,12 +31,19 @@
 </template>
 
 <script>
+// components and mixins
 import fieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
+
+// api request methods
 import { getResource, updateResource } from '@/api/ADempiere/field/binary.js'
 
 export default {
   name: 'FieldImage',
-  mixins: [fieldMixin],
+
+  mixins: [
+    fieldMixin
+  ],
+
   props: {
     // receives the property that is an object with all the attributes
     binary: {
@@ -45,6 +51,7 @@ export default {
       default: () => []
     }
   },
+
   data() {
     return {
       valuesImage: [{
@@ -54,6 +61,7 @@ export default {
       }]
     }
   },
+
   computed: {
     cssClassStyle() {
       let styleClass = ' custom-field-image '
@@ -63,6 +71,7 @@ export default {
       return styleClass
     }
   },
+
   methods: {
     updateResource,
     getResource,

--- a/components/ADempiere/Field/FieldLocator.vue
+++ b/components/ADempiere/Field/FieldLocator.vue
@@ -18,13 +18,9 @@
 
 <template>
   <el-cascader
-    :ref="metadata.columnName"
     :v-model="[value]"
-    :class="cssClassStyle"
-    :placeholder="metadata.placeholder"
+    v-bind="commonsProperties"
     :options="options"
-    :readonly="Boolean(metadata.readonly)"
-    :disabled="isDisabled"
     :clearable="true"
     filterable
     lazy
@@ -37,7 +33,7 @@
 
 <script>
 // components and mixis
-import FieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
+import fieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
 
 // api request methods
 import { getLocatorList } from '@/api/ADempiere/field/locator.js'
@@ -46,7 +42,7 @@ export default {
   name: 'FieldLocation',
 
   mixins: [
-    FieldMixin
+    fieldMixin
   ],
 
   data() {

--- a/components/ADempiere/Field/FieldNumber.vue
+++ b/components/ADempiere/Field/FieldNumber.vue
@@ -27,17 +27,14 @@
     <el-input-number
       v-if="isFocus"
       key="number-input-focus"
-      :ref="metadata.columnName"
       v-model="value"
+      v-bind="commonsProperties"
       type="number"
       :min="minValue"
       :max="maxValue"
-      :placeholder="metadata.placeholder"
-      :disabled="isDisabled"
       :precision="precision"
       :controls="isShowControls"
       :controls-position="controlsPosition"
-      :class="cssClassStyle"
       style="text-align-last: end !important"
       autofocus
       @change="preHandleChange"
@@ -51,11 +48,8 @@
     <el-input
       v-else
       key="number-displayed-blur"
-      :ref="metadata.columnName"
       v-model="displayedValue"
-      :placeholder="metadata.placeholder"
-      :disabled="isDisabled"
-      :class="cssClassStyle"
+      v-bind="commonsProperties"
       readonly
       autofocus
       style="text-align-last: end !important"
@@ -66,7 +60,7 @@
 
 <script>
 // components and mixins
-import FieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
+import fieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
 
 // utils and helper methods
 import { isDecimalField } from '@/utils/ADempiere/references.js'
@@ -76,7 +70,7 @@ export default {
   name: 'FieldNumber',
 
   mixins: [
-    FieldMixin
+    fieldMixin
   ],
 
   data() {

--- a/components/ADempiere/Field/FieldSelect.vue
+++ b/components/ADempiere/Field/FieldSelect.vue
@@ -18,18 +18,15 @@
 
 <template>
   <el-select
-    :ref="metadata.columnName"
     v-model="value"
+    v-bind="commonsProperties"
     :filterable="!isMobile"
-    :placeholder="metadata.placeholder"
     :loading="isLoading"
     value-key="value"
-    :class="cssClassStyle"
     clearable
     :multiple="isSelectMultiple"
     :allow-create="metadata.isSelectCreated"
     :collapse-tags="!isSelectMultiple"
-    :disabled="isDisabled"
     @change="preHandleChange"
     @visible-change="getDataLookupList"
     @clear="clearLookup"

--- a/components/ADempiere/Field/FieldSelectMultiple.vue
+++ b/components/ADempiere/Field/FieldSelectMultiple.vue
@@ -15,14 +15,14 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https:www.gnu.org/licenses/>.
 -->
+
 <template>
   <el-select
     v-model="value"
+    v-bind="commonsProperties"
     multiple
     filterable
     allow-create
-    :placeholder="metadata.placeholder"
-    :class="'custom-field-select custom-field-select-multiple ' + metadata.cssClassName"
     @change="preHandleChange"
   >
     <el-option
@@ -34,6 +34,7 @@
 </template>
 
 <script>
+// components and mixins
 import fieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
 
 /**
@@ -41,8 +42,19 @@ import fieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
  */
 export default {
   name: 'FieldSelectMultiple',
+
   mixins: [
     fieldMixin
-  ]
+  ],
+
+  computed: {
+    cssClassStyle() {
+      let styleClass = ' custom-field-select custom-field-select-multiple '
+      if (!this.isEmptyValue(this.metadata.cssClassName)) {
+        styleClass += this.metadata.cssClassName
+      }
+      return styleClass
+    }
+  }
 }
 </script>

--- a/components/ADempiere/Field/FieldText.vue
+++ b/components/ADempiere/Field/FieldText.vue
@@ -18,15 +18,11 @@
 
 <template>
   <el-input
-    :ref="metadata.columnName"
     v-model="value"
+    v-bind="commonsProperties"
     :pattern="pattern"
     :rows="rows"
-    :class="cssClassStyle"
     :type="typeTextBox"
-    :placeholder="metadata.placeholder"
-    :readonly="Boolean(metadata.readonly)"
-    :disabled="isDisabled"
     :maxlength="maxLength"
     :show-password="Boolean(metadata.isEncrypted)"
     :autofocus="metadata.inTable"
@@ -44,8 +40,8 @@
 
 <script>
 // components and mixins
-import FieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
-import FieldMixinText from '@theme/components/ADempiere/Field/mixin/mixinFieldText.js'
+import fieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
+import fieldMixinText from '@theme/components/ADempiere/Field/mixin/mixinFieldText.js'
 
 // constants
 import { TEXT } from '@/utils/ADempiere/references'
@@ -54,8 +50,8 @@ export default {
   name: 'FieldText',
 
   mixins: [
-    FieldMixin,
-    FieldMixinText
+    fieldMixin,
+    fieldMixinText
   ],
 
   props: {
@@ -123,12 +119,6 @@ export default {
         return 'medium'
       }
       return this.metadata.inputSize
-    },
-    maxLength() {
-      if (!this.isEmptyValue(this.metadata.fieldLength) && this.metadata.fieldLength > 0) {
-        return Number(this.metadata.fieldLength)
-      }
-      return undefined
     }
   }
 }

--- a/components/ADempiere/Field/FieldTextLong.vue
+++ b/components/ADempiere/Field/FieldTextLong.vue
@@ -31,8 +31,8 @@ import 'codemirror/lib/codemirror.css' // codemirror
 import Editor from 'tui-editor'
 
 // components and mixins
-import FieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
-import FieldMixinText from '@theme/components/ADempiere/Field/mixin/mixinFieldText.js'
+import fieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
+import fieldMixinText from '@theme/components/ADempiere/Field/mixin/mixinFieldText.js'
 
 // utils and helper methods
 import { getLanguage } from '@/lang'
@@ -41,8 +41,8 @@ export default {
   name: 'FieldTextLong',
 
   mixins: [
-    FieldMixin,
-    FieldMixinText
+    fieldMixin,
+    fieldMixinText
   ],
 
   props: {

--- a/components/ADempiere/Field/FieldTime.vue
+++ b/components/ADempiere/Field/FieldTime.vue
@@ -17,18 +17,14 @@
 -->
 <template>
   <el-time-picker
-    :ref="metadata.columnName"
     v-model="value"
+    v-bind="commonsProperties"
     :picker-options="{
       minTime: minValue,
       maxTime: maxValue
     }"
     :is-range="isPickerRange"
     range-separator="-"
-    :placeholder="$t('components.timePlaceholder')"
-    :class="cssClassStyle"
-    :readonly="Boolean(metadata.readonly)"
-    :disabled="isDisabled"
     @change="preHandleChange"
     @blur="focusLost"
     @focus="focusGained"
@@ -39,13 +35,13 @@
 
 <script>
 // components and mixins
-import FieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
+import fieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
 
 export default {
   name: 'FieldTime',
 
   mixins: [
-    FieldMixin
+    fieldMixin
   ],
 
   computed: {

--- a/components/ADempiere/Field/FieldYesNo.vue
+++ b/components/ADempiere/Field/FieldYesNo.vue
@@ -18,12 +18,10 @@
 
 <template>
   <el-switch
-    :ref="metadata.columnName"
     v-model="value"
+    v-bind="commonsProperties"
     :active-text="$t('components.switchActiveText')"
     :inactive-text="$t('components.switchInactiveText')"
-    :class="cssClassStyle"
-    :disabled="isDisabled"
     @change="preHandleChange"
     @blur="focusLost"
     @focus="focusGained"
@@ -31,8 +29,10 @@
 </template>
 
 <script>
+// components and mixins
 import fieldMixin from '@theme/components/ADempiere/Field/mixin/mixinField.js'
 
+// utils and helper methods
 import { convertStringToBoolean } from '@/utils/ADempiere/formatValue/booleanFormat.js'
 
 export default {

--- a/components/ADempiere/Field/mixin/mixinField.js
+++ b/components/ADempiere/Field/mixin/mixinField.js
@@ -43,6 +43,18 @@ export default {
     isDisabled() {
       return Boolean(this.metadata.readonly || this.metadata.disabled)
     },
+    /**
+     * Commons properties in components fields
+     */
+    commonsProperties() {
+      return {
+        class: this.cssClassStyle,
+        disabled: this.isDisabled,
+        placeholder: this.metadata.placeholder,
+        readonly: Boolean(this.metadata.readonly),
+        ref: this.metadata.columnName
+      }
+    },
     cssClassStyle() {
       let styleClass = ''
       if (this.isEmptyRequired) {

--- a/components/ADempiere/Field/mixin/mixinFieldText.js
+++ b/components/ADempiere/Field/mixin/mixinFieldText.js
@@ -23,6 +23,12 @@ export default {
         value = ''
       }
       return String(value)
+    },
+    maxLength() {
+      if (!this.isEmptyValue(this.metadata.fieldLength) && this.metadata.fieldLength > 0) {
+        return Number(this.metadata.fieldLength)
+      }
+      return undefined
     }
   }
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Components that extend `FieldDefinition` use common properties that are specified in each specific component.

With this change they are simply defined as objects within the computed `commonsProperties` in the `mixinField`, and those properties are instantiated in the template of each component that uses the `mixinField`.

If a change is required associated with the properties: 
* class: this.cssClassStyle.
* disabled: this.isDisabled.
* placeholder: this.metadata.placeholder.
* readonly: Boolean(this.metadata.readonly).
* ref: this.metadata.columnName.

Or add a new common property of the template will not be necessary to modify each component that uses `mixinField`.


#### Other relevant information
- Your OS: Linux Mint 20.3 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

