### PR TITLE
keep the type of report when changing the print format

### DIFF
--- a/components/ADempiere/ActionMenu/Actions.vue
+++ b/components/ADempiere/ActionMenu/Actions.vue
@@ -156,6 +156,10 @@ export default defineComponent({
       default: () => {},
       required: true
     },
+    reportFormat: {
+      type: String,
+      default: ''
+    },
     size: {
       type: String,
       default: ''
@@ -231,6 +235,7 @@ export default defineComponent({
         tableName,
         containerManager: props.containerManager,
         recordUuid: recordUuid.value,
+        reportFormat: props.reportFormat,
         uuid: action.uuid
       })
     }

--- a/components/ADempiere/ActionMenu/index.vue
+++ b/components/ADempiere/ActionMenu/index.vue
@@ -24,6 +24,7 @@
       :container-uuid="containerUuid"
       :size="size"
       :actions-manager="actionsManager"
+      :report-format="reportFormat"
     />
 
     <menu-relations
@@ -79,6 +80,10 @@ export default defineComponent({
     relationsManager: {
       type: Object,
       default: () => {}
+    },
+    reportFormat: {
+      type: String,
+      default: ''
     }
   },
 

--- a/components/ADempiere/TabManager/index.vue
+++ b/components/ADempiere/TabManager/index.vue
@@ -301,7 +301,7 @@ export default defineComponent({
         columnName: UUID
       })
     })
-    
+
     const currentTabTableName = computed(() => {
       return store.getters.getTableName(
         props.parentUuid,


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
keep the type of report when changing the print format
#### Steps to reproduce

1. Open a generated PDF report
2. After it is generated, change the print format or the view of the report
3. Observe the error (the print format or the view of the report is not generated in PDF, it is always generated in HTML)

### Screenshot or Gif
#### GIF Error
![error-vue](https://user-images.githubusercontent.com/45974454/167941692-7b03c625-821b-4b29-a266-3b408855d4f1.gif)

#### GIF  Expected behavior (Interface ZK)
![zk](https://user-images.githubusercontent.com/45974454/167941756-59fe8e50-dc72-424a-9ded-f9b5f8193543.gif)

#### GIF Success
![success](https://user-images.githubusercontent.com/45974454/167941913-a1733adb-c8e9-4bca-8589-75d68c61be15.gif)


#### Other relevant information
- Your OS: Debian 9
- Web Browser: Chrome
- Node.js version: v 14.0.0
- Yarn version: v 1.22.0
- adempiere-vue version: v 4.4.0.

#### Additional context
Note: This PR is linked with the following PR of the [Frontend Core](https://github.com/solop-develop/frontend-core) [#51](https://github.com/solop-develop/frontend-core/pull/51)

