### PR TITLE
feat: Generated report with last parameters.

### DIFF
--- a/components/ADempiere/ActionMenu/Actions.vue
+++ b/components/ADempiere/ActionMenu/Actions.vue
@@ -90,20 +90,22 @@
                     :command="actionChild"
                     :divided="true"
                   >
-                    <span class="contents">
-                      <b class="label" @click="runAction(actionChild)">
-                        {{ actionChild.name }}
-                      </b>
-                    </span>
+                    <div @click="runAction(actionChild)">
+                      <span class="contents">
+                        <b class="label">
+                          {{ actionChild.name }}
+                        </b>
+                      </span>
 
-                    <p class="description" @click="runAction(actionChild)">
-                      <template v-if="isEmptyValue(actionChild.description)">
-                        {{ $t('data.noDescription') }}
-                      </template>
-                      <template v-else>
-                        {{ actionChild.description }}
-                      </template>
-                    </p>
+                      <p class="description">
+                        <template v-if="isEmptyValue(actionChild.description)">
+                          {{ $t('data.noDescription') }}
+                        </template>
+                        <template v-else>
+                          {{ actionChild.description }}
+                        </template>
+                      </p>
+                    </div>
                   </el-dropdown-item>
                 </el-scrollbar>
               </el-dropdown-menu>
@@ -155,10 +157,6 @@ export default defineComponent({
       type: Object,
       default: () => {},
       required: true
-    },
-    reportFormat: {
-      type: String,
-      default: ''
     },
     size: {
       type: String,
@@ -237,7 +235,6 @@ export default defineComponent({
         instanceUuid,
         containerManager: props.containerManager,
         recordUuid: recordUuid.value,
-        reportFormat: props.reportFormat,
         uuid: action.uuid
       })
     }

--- a/components/ADempiere/ActionMenu/index.vue
+++ b/components/ADempiere/ActionMenu/index.vue
@@ -24,7 +24,6 @@
       :container-uuid="containerUuid"
       :size="size"
       :actions-manager="actionsManager"
-      :report-format="reportFormat"
     />
 
     <menu-relations
@@ -80,10 +79,6 @@ export default defineComponent({
     relationsManager: {
       type: Object,
       default: () => {}
-    },
-    reportFormat: {
-      type: String,
-      default: ''
     }
   },
 

--- a/components/ADempiere/FileRender/PdfFile/index.vue
+++ b/components/ADempiere/FileRender/PdfFile/index.vue
@@ -25,7 +25,7 @@
     <embed
       class="pdf-content"
       :src="src"
-      :type="typeFormat"
+      :type="mimeType"
       style="height:1000px;width:100%; position:relative;"
     >
   </div>
@@ -33,6 +33,7 @@
 
 <script>
 import { defineComponent } from '@vue/composition-api'
+
 // components and mixins
 import DownloadFile from '@theme/components/ADempiere/FileRender/downloadFile.vue'
 
@@ -48,9 +49,21 @@ export default defineComponent({
       type: String,
       required: true
     },
-    typeFormat: {
+    mimeType: {
       type: String,
       default: 'application/pdf'
+    },
+    format: {
+      type: String,
+      required: true
+    },
+    name: {
+      type: String,
+      default: undefined
+    },
+    stream: {
+      type: [Object, Array],
+      default: undefined
     }
   }
 

--- a/components/ADempiere/FileRender/downloadFile.vue
+++ b/components/ADempiere/FileRender/downloadFile.vue
@@ -56,6 +56,7 @@ import { defineComponent, computed } from '@vue/composition-api'
 // utils and helper methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
 import { buildLinkHref } from '@/utils/ADempiere/resource'
+import { DEFAULT_REPORT_TYPE } from '@/utils/ADempiere/dictionary/report'
 
 export default defineComponent({
   name: 'DownloadFile',
@@ -67,7 +68,7 @@ export default defineComponent({
     },
     format: {
       type: String,
-      default: 'xlsx'
+      default: DEFAULT_REPORT_TYPE
     },
     name: {
       type: String,
@@ -113,7 +114,7 @@ export default defineComponent({
     function downloadOtherFile(format) {
       root.$store.dispatch('downloadReport', {
         containerUuid: root.$route.params.reportUuid,
-        reportFormat: format
+        reportType: format
       })
     }
 

--- a/router/modules/ADempiere/staticRoutes.js
+++ b/router/modules/ADempiere/staticRoutes.js
@@ -62,7 +62,7 @@ const staticRoutes = [
         name: 'Report Viewer',
         meta: {
           title: language.t('route.reportViewer'),
-          reportFormat: ''
+          reportType: ''
         }
       }
     ]


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Shipment Details` report.
2. Generate as `html` report type.
3. Generate changes in the report view

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/168943738-2ce2f937-3d13-4601-a9ee-00190b760211.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/168943740-fb03a648-e70d-4660-9a9f-265f613a3bf4.mp4

#### Expected behavior
If only the report view (or print format) is changed, it should keep the same report type (pdf for this case) or extension from where it is being generated, unless the report type is explicitly changed.

#### Other relevant information
- Your OS: Linux Mint 20.3 x64.
- Web Browser: Mozilla Firefox 99.0
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.


