### PR TITLE
feat: Displayed report associated in button field.

### DIFF
--- a/components/ADempiere/ActionMenu/Actions.vue
+++ b/components/ADempiere/ActionMenu/Actions.vue
@@ -47,6 +47,10 @@
       <el-scrollbar v-else key="withActions" wrap-class="scroll-child">
         <el-dropdown-item
           v-for="(action, index) in actionsList"
+          v-show="!action.displayed || (action.displayed && action.displayed({
+            parentUuid,
+            containerUuid
+          }))"
           :key="index"
           :command="action"
           :disabled="!action.enabled({
@@ -135,7 +139,7 @@
 </template>
 
 <script>
-import { computed, defineComponent, ref } from '@vue/composition-api'
+import { computed, defineComponent } from '@vue/composition-api'
 
 export default defineComponent({
   name: 'MenuActions',
@@ -173,10 +177,12 @@ export default defineComponent({
 
     const instanceUuid = root.$route.params.instanceUuid
     // set initial value
-    const actionsList = ref([])
-    if (props.actionsManager && props.actionsManager.getActionList) {
-      actionsList.value = props.actionsManager.getActionList()
-    }
+    const actionsList = computed(() => {
+      if (props.actionsManager && props.actionsManager.getActionList) {
+        return props.actionsManager.getActionList()
+      }
+      return []
+    })
 
     const recordUuid = computed(() => {
       // TODO: Change query name 'action'


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Business Partner` window.
2. Select `Customer` tab.
3. List actions menu.
4. Change value of field `Is Customer`.
5. Select `Open Items` report on action menu.

#### Screenshot or Gif

Vue Version:

https://user-images.githubusercontent.com/20288327/169158329-08b5b324-2974-447d-a6a8-fb36af0fecc3.mp4

https://user-images.githubusercontent.com/20288327/169158331-ad34e676-2d0a-467d-a7f5-0e4ec4c44681.mp4

Zk Version:

https://user-images.githubusercontent.com/20288327/169158335-5e784af6-c721-40e6-a471-ce7f0d28e3c3.mp4


#### Other relevant information
- Your OS: Linux Mint 20.3 x64.
- Web Browser: Mozilla Firefox 99.0
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Note that the display logic of the action menu process is the same as the button field that has the process associated with it.
