### PR TITLE
feat: Add open Smart Browser associated.

### DIFF
--- a/components/ADempiere/ActionMenu/Actions.vue
+++ b/components/ADempiere/ActionMenu/Actions.vue
@@ -63,7 +63,16 @@
         >
           <div class="contents">
             <div class="auxiliary-menu-icon">
-              <i :class="action.icon" style="font-size: 18" />
+              <svg-icon
+                v-if="action.isSvgIcon"
+                :icon-class="action.icon"
+                style="font-size: 18"
+              />
+              <i
+                v-else
+                :class="action.icon"
+                style="font-size: 18"
+              />
             </div>
 
             <!-- for print format -->


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Payment Selection` window.
2. Expand actions menu.
3. Select `Create Payment From Selection` smart browser.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/170128727-09915159-bff6-44ec-a7b4-3044327fb51c.mp4



#### Other relevant information
- Your OS: Linux Mint 20.3 x64.
- Web Browser: Mozilla Firefox 99.0
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
These smart browsers are associated to a process and these in turn are associated to a table/button.

For these cases the Smart Browser does not exist in the menu, therefore it is loaded in the route in the following way

`browser/browserId/browserUuid?parentUuid`

`browser`: Locates the view of the component
`browserId`: This parameter must have the id of the smart browser, by default in 0.
`browserUuid`: This parameter is the uuid of the smart browser to get information.
`parrentUuid`: This parameter indicates the window from which the context to be set in the smart browser was used.

Example:

http://0.0.0.0:9527/#/browser/0/8aaeea60-fb40-11e8-a479-7a0060f0aa01?parentUuid=a5210e14-fb40-11e8-a479-7a0060f0aa01

