### PR TITLE
fix: SB Dynamic validation with element name.

### DIFF
--- a/components/ADempiere/Field/FieldSelect.vue
+++ b/components/ADempiere/Field/FieldSelect.vue
@@ -146,6 +146,15 @@ export default {
           columnName,
           value
         })
+        // update element column name
+        if (columnName !== this.metadata.elementName) {
+          this.$store.commit('updateValueOfField', {
+            parentUuid: this.metadata.parentUuid,
+            containerUuid,
+            columnName: this.metadata.elementName,
+            value
+          })
+        }
       }
     },
     uuidValue: {
@@ -246,7 +255,7 @@ export default {
     'metadata.displayed'(value) {
       if (value) {
         // if is field showed, search into store all options to list
-        this.optionsList = this.getLookupAll
+        this.optionsList = this.getStoredLookupAll
       }
     },
     value(newValue) {
@@ -275,7 +284,7 @@ export default {
 
   beforeMount() {
     if (this.metadata.displayed) {
-      this.optionsList = this.getLookupAll
+      this.optionsList = this.getStoredLookupAll
       const value = this.value
       if (!this.isEmptyValue(value) && !this.metadata.isAdvancedQuery) {
         const option = this.findOption(value)
@@ -341,7 +350,7 @@ export default {
             this.displayedValue = responseLookupItem.displayedValue
             this.uuidValue = responseLookupItem.uuid
             this.$nextTick(() => {
-              this.optionsList = this.getLookupAll
+              this.optionsList = this.getStoredLookupAll
             })
           }
         })
@@ -354,7 +363,7 @@ export default {
      */
     getDataLookupList(isShowList) {
       // get stored list values
-      const list = this.getLookupList
+      const list = this.getStoredLookupList
       // refresh local list component
       this.optionsList = list
       if (isShowList) {
@@ -404,7 +413,7 @@ export default {
           if (!this.isEmptyValue(responseLookupList)) {
             this.optionsList = responseLookupList
           } else {
-            this.optionsList = this.getLookupAll
+            this.optionsList = this.getStoredLookupAll
           }
         })
         .finally(() => {

--- a/components/ADempiere/Field/mixin/mixinField.js
+++ b/components/ADempiere/Field/mixin/mixinField.js
@@ -293,6 +293,13 @@ export default {
           columnName: this.metadata.columnName,
           value
         })
+        if (this.metadata.columnName !== this.metadata.elementName) {
+          this.$store.dispatch('notifyActionPerformed', {
+            containerUuid: this.metadata.containerUuid,
+            columnName: this.metadata.elementName,
+            value
+          })
+        }
       }
 
       // if is custom field, set custom handle change value

--- a/components/ADempiere/Field/mixin/mixinFieldSelect.js
+++ b/components/ADempiere/Field/mixin/mixinFieldSelect.js
@@ -49,10 +49,12 @@ export default {
         value
       }
     },
-    getLookupList() {
+    getStoredLookupList() {
       if (!this.metadata.displayed) {
         return [this.blankOption]
       }
+
+      // add blanck option in firts element on list
       return this.$store.getters.getStoredLookupList({
         parentUuid: this.metadata.parentUuid,
         containerUuid: this.metadata.containerUuid,
@@ -64,7 +66,7 @@ export default {
         columnName: this.metadata.columnName
       })
     },
-    getLookupAll() {
+    getStoredLookupAll() {
       const allOptions = this.$store.getters.getStoredLookupAll({
         parentUuid: this.metadata.parentUuid,
         containerUuid: this.metadata.containerUuid,


### PR DESCRIPTION
Abrir la consulta inteligente `Generar Plan de Recolección basado en ventas`.

* Listar los valores del campo `País`.
* Seleccionar un valor.
* Listar los valores del campo `Región`, y verificar que los resultados pertenezcan a la región seleccionada.




https://user-images.githubusercontent.com/20288327/171282972-c37aa3bb-1ba0-466a-8239-67ab1b7c33b0.mp4

https://user-images.githubusercontent.com/20288327/171284272-1b22e4f1-26fc-44c7-9080-3a0beac40da7.mp4



En las consultas inteligentes del Zk o del Swing no parecen funcionar bien las validaciones dinámicas.


https://user-images.githubusercontent.com/20288327/171284331-78de75c0-611d-48e3-8333-dfc541201a06.mp4
