### PR TITLE
fix: Set new values when change parent recrod.

### DIFF
--- a/components/ADempiere/DefaultTable/index.vue
+++ b/components/ADempiere/DefaultTable/index.vue
@@ -105,6 +105,8 @@
 <script>
 import { defineComponent, computed, onMounted, ref } from '@vue/composition-api'
 
+import store from '@/store'
+
 // components and mixins
 import CellInfo from './CellInfo.vue'
 import ColumnsDisplayOption from './ColumnsDisplayOption'
@@ -177,7 +179,7 @@ export default defineComponent({
     })
 
     const currentOption = computed(() => {
-      return root.$store.getters.getTableOption
+      return store.getters.getTableOption
     })
 
     const keyColumn = computed(() => {
@@ -322,10 +324,10 @@ export default defineComponent({
     function filterRecord(searchText) {
       isLoadFilter.value = true
 
-      root.$store.dispatch('getEntities', {
+      store.dispatch('getEntities', {
         parentUuid: props.parentUuid,
         containerUuid: props.containerUuid,
-        searhValue: searchText
+        searchValue: searchText
       })
         .finally(() => {
           clearTimeout(timeOut.value)

--- a/components/ADempiere/Field/mixin/mixinField.js
+++ b/components/ADempiere/Field/mixin/mixinField.js
@@ -152,8 +152,9 @@ export default {
       // set value into component and fieldValue store
       this.value = this.parseValue(value)
 
-      // set value and change into store
-      this.preHandleChange(value)
+      // change depends fields
+      // this.preHandleChange(value)
+      this.activeLogics()
     }
   },
 
@@ -192,9 +193,10 @@ export default {
       }
 
       // return default parsed value
-      return Promise.resolve(
-        this.parseValue(this.value)
-      )
+      return Promise.resolve({
+        value: this.parseValue(this.value),
+        displayedValue: undefined
+      })
     },
 
     /**
@@ -275,6 +277,27 @@ export default {
         })
       }
     },
+
+    /**
+     * Active or calling change logics on depends fields
+     */
+    activeLogics() {
+      let fieldsList = []
+      if (this.containerManager.getFieldsList) {
+        fieldsList = this.containerManager.getFieldsList({
+          parentUuid: this.metadata.parentUuid,
+          containerUuid: this.metadata.containerUuid,
+          root: this
+        })
+      }
+
+      this.$store.dispatch('changeDependentFieldsList', {
+        field: this.metadata,
+        fieldsList,
+        containerManager: this.containerManager
+      })
+    },
+
     /**
      * @param {mixed} value, main value in component
      * @param {mixed} valueTo, used in end value in range
@@ -304,18 +327,7 @@ export default {
       // if is custom field, set custom handle change value
       if (this.metadata.isCustomField) {
         if (this.metadata.isActiveLogics) {
-          let fieldsList = []
-          if (this.containerManager.getFieldsList) {
-            fieldsList = this.containerManager.getFieldsList({
-              parentUuid: this.metadata.parentUuid,
-              containerUuid: this.metadata.containerUuid,
-              root: this
-            })
-          }
-          this.$store.dispatch('changeDependentFieldsList', {
-            field: this.metadata,
-            fieldsList
-          })
+          this.activeLogics()
         }
         return
       }

--- a/components/ADempiere/TabManager/TabPanel.vue
+++ b/components/ADempiere/TabManager/TabPanel.vue
@@ -63,30 +63,9 @@ export default defineComponent({
       type: Object,
       required: true
     },
-    allTabsList: {
-      type: Array,
-      required: false
-    },
-    tabsList: {
-      type: Array,
-      default: () => []
-    },
-    isParentTabs: {
-      type: Boolean,
-      default: true
-    },
     currentTabUuid: {
       type: String,
       default: ''
-    },
-    actionsManager: {
-      type: Object,
-      default: () => ({})
-    },
-    // used only window
-    referencesManager: {
-      type: Object,
-      default: () => ({})
     },
     tabAttributes: {
       type: Object,


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with `System Role`.
2. Open `View` window.
3. Set any record.

#### Screenshot or Gif


https://user-images.githubusercontent.com/20288327/172940918-61a673f5-80f6-49cc-a55a-2787c34491e7.mp4


#### Expected behavior

If the record on the top tab changes, the records on the child tab must be updated.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 100.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Related https://github.com/solop-develop/backend/pull/21
