### PR TITLE
fix: Generate report view with output.

### DIFF
--- a/components/ADempiere/Form/ProductInfo/index.vue
+++ b/components/ADempiere/Form/ProductInfo/index.vue
@@ -36,7 +36,8 @@
  * This component is made to be the prototype of the Product Info search field
  */
 import ProductInfoList from './productList'
-import staticReportRoutes from '@/utils/ADempiere/constants/report'
+import { staticReportRoutes } from '@/utils/ADempiere/constants/report'
+
 import {
   formatPrice,
   formatQuantity


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

Currently when changing a report view the report is generated with ProcessBuilder but it does not support report view, instead it must be called ReportOutput.

#### Steps to reproduce

1. Open `Shipment Detail`.
2. Generate report.
3. Change between report view.


#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/176031104-3dcc8bb5-50ea-4e5a-8d36-6a05a5b6c979.mp4


#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 100.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
the report view for the data filter is not being set correctly in the backend.
