### PR TITLE
fix: Set default values on tab childs.

### DIFF
--- a/components/ADempiere/DefaultTable/CellInfo.vue
+++ b/components/ADempiere/DefaultTable/CellInfo.vue
@@ -87,16 +87,14 @@ import DocumentStatusTag from '@theme/components/ADempiere/ContainerOptions/Docu
 import FieldDefinition from '@theme/components/ADempiere/Field/index.vue'
 // utils and helpers methods
 import { isEmptyValue, typeValue } from '@/utils/ADempiere/valueUtils.js'
-import {
-  formatField, formatPrice, formatQuantity
-} from '@/utils/ADempiere/valueFormat.js'
+import { formatField } from '@/utils/ADempiere/valueFormat.js'
 import { convertBooleanToTranslationLang } from '@/utils/ADempiere/formatValue/booleanFormat.js'
+import { formatNumber } from '@/utils/ADempiere/formatValue/numberFormat'
 
 // constants
 import {
   OPERATORS_FIELD_TEXT_LONG
 } from '@/utils/ADempiere/dataUtils'
-import { FIELDS_CURRENCY } from '@/utils/ADempiere/references.js'
 
 export default defineComponent({
   name: 'CellInfo',
@@ -162,17 +160,6 @@ export default defineComponent({
       return classCss
     })
 
-    const formatNumber = ({ displayType, value }) => {
-      if (isEmptyValue(value)) {
-        value = 0
-      }
-      // Amount, Costs+Prices
-      if (FIELDS_CURRENCY.includes(displayType)) {
-        return formatPrice(value)
-      }
-      return formatQuantity(value)
-    }
-
     /**
      * @param {object} row, row data
      * @param {object} field, field with attributes
@@ -198,6 +185,7 @@ export default defineComponent({
             valueToShow = undefined
             break
           }
+          // TODO: Add currency of row
           valueToShow = formatNumber({
             displayType,
             value: fieldValue.value

--- a/components/ADempiere/Field/FieldSelect.vue
+++ b/components/ADempiere/Field/FieldSelect.vue
@@ -341,6 +341,12 @@ export default {
             this.value = responseLookupItem.value
             this.displayedValue = responseLookupItem.displayedValue
             this.uuidValue = responseLookupItem.uuid
+
+            // TODO: With remote and filter is enabled not working displayed value
+            // https://github.com/ElemeFE/element/issues/20706
+            // https://github.com/ElemeFE/element/issues/21287
+            // https://github.com/ElemeFE/element/issues/21465
+            this.optionsList = []
             this.$nextTick(() => {
               this.optionsList = this.getStoredLookupAll
             })


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with `GardenAdmin`.
2. Open `View` window.
3. In `View Definition` tab select aciton menu `Create New`

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/173836388-c6abb7e2-1fe1-4b9d-bacc-c7be530f0866.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/173836395-b5f8b533-d529-4848-940b-4b311bc379ed.mp4



#### Expected behavior
If record parent is other cliend expected showed correct displayed value in `Client` field.

`View` field is parent column and without default value, set parent record value.


#### Other relevant information

- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 100.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

