### PR TITLE
feat: Run process add record as parameter.

### DIFF
--- a/components/ADempiere/Field/FieldButton.vue
+++ b/components/ADempiere/Field/FieldButton.vue
@@ -38,7 +38,9 @@ import {
   generateReportOfWindow,
   openBrowserAssociated
 } from '@/utils/ADempiere/dictionary/window.js'
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
 
+// TODO: Add displayed value
 export default {
   name: 'FieldButton',
 
@@ -48,7 +50,7 @@ export default {
 
   computed: {
     iconProps() {
-      if (this.metadata.process) {
+      if (!isEmptyValue(this.metadata.process)) {
         if (this.metadata.process.isReport || this.metadata.process.jasperReport) {
           return {
             is: 'i',
@@ -70,12 +72,14 @@ export default {
           }
         }
 
+        // is process
         return {
-          is: 'svg-icon',
-          'icon-class': 'search'
+          is: 'i',
+          'class': 'el-icon-setting'
         }
       }
 
+      // button without process associated
       return {
         is: 'span'
       }

--- a/components/ADempiere/PanelDefinition/StandardPanel.vue
+++ b/components/ADempiere/PanelDefinition/StandardPanel.vue
@@ -64,6 +64,9 @@ import store from '@/store'
 import FieldDefinition from '@theme/components/ADempiere/Field/index.vue'
 import FilterFields from '@theme/components/ADempiere/FilterFields/index.vue'
 
+// utils and helper methods
+import { isEmptyValue } from '@/utils/ADempiere'
+
 export default defineComponent({
   name: 'StandardPanel',
 
@@ -97,14 +100,24 @@ export default defineComponent({
   },
 
   setup(props) {
-    let fieldsList = []
-
-    const generatePanel = () => {
+    const fieldsList = computed(() => {
       // order and assign groups
-      if (props.panelMetadata) {
-        fieldsList = props.panelMetadata.fieldsList
+      if (!isEmptyValue(props.panelMetadata) && !isEmptyValue(props.panelMetadata.fieldsList)) {
+        return props.panelMetadata.fieldsList
       }
-    }
+
+      if (!isEmptyValue(props.containerManager) && props.containerManager.getFieldsList) {
+        const fields = props.containerManager.getFieldsList({
+          parentUuid: props.parentUuid,
+          containerUuid: props.containerUuid
+        })
+        if (!isEmptyValue(fields)) {
+          return fields
+        }
+      }
+
+      return []
+    })
 
     const shadowGroup = computed(() => {
       if (store.state.app.device === 'mobile') {
@@ -112,8 +125,6 @@ export default defineComponent({
       }
       return 'hover'
     })
-
-    generatePanel()
 
     return {
       fieldsList,

--- a/components/ADempiere/PanelDefinition/index.vue
+++ b/components/ADempiere/PanelDefinition/index.vue
@@ -21,7 +21,7 @@
     :is="componentRender"
     :parent-uuid="parentUuid"
     :container-uuid="containerUuid"
-    :container-manager="containerManager"
+    :container-manager="containerManagerPanel"
     :panel-metadata="panelMetadata"
     :is-show-filter="isShowFilter"
   />
@@ -52,13 +52,17 @@ export default defineComponent({
     }
   },
 
-  setup(props, { root }) {
-    if (root.$route.query.action === 'create-new') {
-      props.containerManager.setDefaultValues({
-        parentUuid: props.parentUuid,
-        containerUuid: props.containerUuid
-      })
-    }
+  setup(props) {
+    const containerManagerPanel = computed(() => {
+      return props.containerManager
+    })
+
+    // if (root.$route.query.action === 'create-new') {
+    //   containerManagerPanel.value.setDefaultValues({
+    //     parentUuid: props.parentUuid,
+    //     containerUuid: props.containerUuid
+    //   })
+    // }
 
     const componentRender = computed(() => {
       const panelComponent = () => import('@theme/components/ADempiere/PanelDefinition/StandardPanel.vue')
@@ -70,14 +74,15 @@ export default defineComponent({
      * the fields it contains
      */
     const panelMetadata = computed(() => {
-      return props.containerManager.getPanel({
+      return containerManagerPanel.value.getPanel({
         parentUuid: props.parentUuid,
         containerUuid: props.containerUuid
-      })
+      }) || {}
     })
 
     return {
       // computeds
+      containerManagerPanel,
       panelMetadata,
       componentRender
     }


### PR DESCRIPTION
Add record as parameter from which process or report was executed


https://user-images.githubusercontent.com/20288327/174331971-eb4e5229-2a4c-4f0e-aa55-7245958e3316.mp4

#### Steps to reproduce
1. Login with GardenAdmin.
2. Open `Business Partner` window.
3. Select `Customer` tab.
4. Click in `Open Items` field button.
5. See key column (Business Partner) in report.

#### Additional context
cURL request

```shell
curl 'http://localhost:8085/api/adempiere/common/api/process?token=26bf0542-2a72-4808-8974-9d4927bf077a&language=en' \
  -X POST \
  -H 'Content-Type: application/json' \
  --data-raw '{"process_uuid":"a42cfc20-fb40-11e8-a479-7a0060f0aa01","table_name":"C_BPartner","uuid":"c3cfeb5f-1b2f-4f4b-a16c-d9cda23f59e1","report_type":"pdf","parameters":[{"key":"DaysDue","value":-99999},{"key":"DaysDue_To","value":99999}]}'
```
