### PR TITLE
feat: Convenience buttons.

### DIFF
--- a/components/ADempiere/ActionMenu/index.vue
+++ b/components/ADempiere/ActionMenu/index.vue
@@ -32,6 +32,9 @@
 <script>
 import { defineComponent, computed } from '@vue/composition-api'
 
+import store from '@/store'
+
+// components and mixins
 import MenuActions from './Actions.vue'
 import MenuReferences from './References.vue'
 
@@ -67,16 +70,16 @@ export default defineComponent({
     }
   },
 
-  setup(props, { root }) {
+  setup() {
     const isMobile = computed(() => {
-      return root.$store.getters.device === 'mobile'
+      return store.getters.device === 'mobile'
     })
 
     const size = computed(() => {
       if (isMobile.value) {
         return 'mini'
       }
-      return 'medium'
+      return 'small'
     })
 
     return {

--- a/components/ADempiere/TabManager/TabOptions.vue
+++ b/components/ADempiere/TabManager/TabOptions.vue
@@ -17,25 +17,32 @@
 -->
 
 <template>
-  <span>
-    <el-button
-      plain
-      size="small"
-      type="text"
-      style="height: 93%;margin-right: 0%;padding-right: 10px; float: left;"
-      class="alo"
-      @click="changeShowedRecords"
-    >
-      <span
-        style="padding: 10px;"
+  <span class="tab-options-main">
+    <div style="height: 93%;margin-right: 0%;padding-right: 10px; float: left; display: inline-flex;">
+      <el-button
+        plain
+        size="small"
+        type="text"
+        @click="changeShowedRecords"
       >
-        <svg-icon icon-class="table" />
-        <b>
-          {{ label }}
-        </b>
-      </span>
-    </el-button>
-    <div style="float: right;padding-left: 1%;">
+        <span style="padding: 10px;">
+          <svg-icon icon-class="table" />
+          <b>
+            {{ label }}
+          </b>
+        </span>
+      </el-button>
+
+      <convenience-buttons
+        :parent-uuid="parentUuid"
+        :container-uuid="currentTabUuid"
+        :container-manager="containerManager"
+        :tab-attributes="tabAttributes"
+      />
+    </div>
+
+    <div style="float: right; padding-left: 1%; display: inline-flex;">
+
       <action-menu
         :parent-uuid="parentUuid"
         :container-uuid="currentTabUuid"
@@ -55,12 +62,14 @@ import store from '@/store'
 
 // components and mixins
 import ActionMenu from '@theme/components/ADempiere/ActionMenu/index.vue'
+import ConvenienceButtons from '@theme/components/ADempiere/TabManager/convenienceButtons.vue'
 
 export default defineComponent({
   name: 'TabOptions',
 
   components: {
-    ActionMenu
+    ActionMenu,
+    ConvenienceButtons
   },
 
   props: {
@@ -102,6 +111,7 @@ export default defineComponent({
         containerUuid: props.tabAttributes.uuid,
         defaultActionName: language.t('actionMenu.createNewRecord'),
         tableName: props.tabAttributes.tableName,
+        withoutDefaulAction: true,
         getActionList: () => {
           return store.getters.getStoredActionsMenu({
             containerUuid: props.tabAttributes.uuid
@@ -109,6 +119,7 @@ export default defineComponent({
         }
       }
     })
+
     const isShowedTableRecords = computed(() => {
       return tabData.value.isShowedTableRecords
     })
@@ -132,7 +143,6 @@ export default defineComponent({
     const recordsList = computed(() => {
       return tabData.value.recordsList
     })
-
 
     const label = computed(() => {
       if (isShowedTableRecords.value) {
@@ -158,7 +168,7 @@ export default defineComponent({
       isShowedTableRecords,
       tableHeaders,
       label,
-      // methodo
+      // methods
       changeShowedRecords
     }
   }


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window.
2. Select `New` button.
3. Select `Undo` button.

See how the buttons are displayed/hidden as convenient for the management of the registry

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/174878998-00cabb60-b1cc-4963-988d-e4bcf99f3b1f.mp4


#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.
