### PR TITLE
feat: Showed default fields.

### DIFF
--- a/components/ADempiere/CollapseCriteria/index.vue
+++ b/components/ADempiere/CollapseCriteria/index.vue
@@ -35,6 +35,7 @@
           :fields-list="fieldsList"
           :filter-manager="containerManager.changeFieldShowedFromUser"
           :showed-manager="containerManager.isDisplayedField"
+          :fields-to-hidden="containerManager.getFieldsToHidden"
         />
       </el-col>
       <el-col :span="1" style="text-align: center;">

--- a/components/ADempiere/Field/index.vue
+++ b/components/ADempiere/Field/index.vue
@@ -258,8 +258,12 @@ export default {
       }
       // validate with container manager
       if (this.containerManager.isDisplayedField(this.field)) {
-        // mandatory not parent column without default value
-        if (this.isMandatoryField && !this.field.isParent && isEmptyValue(this.field.defaultValue)) {
+        const isDisplayedDefault = this.containerManager.isDisplayedDefault({
+          ...this.field,
+          isMandatory: this.isMandatoryField
+        })
+        // madatory. not parent column and without default value to window, mandatory or with default value to others
+        if (isDisplayedDefault) {
           return true
         }
 

--- a/components/ADempiere/FilterFields/index.vue
+++ b/components/ADempiere/FilterFields/index.vue
@@ -90,6 +90,10 @@ export default defineComponent({
       type: Function,
       default: ({ filterList }) => { return true }
     },
+    fieldsToHidden: {
+      type: Function,
+      default: ({ filterList }) => { return [] }
+    },
     // isDisplayedField or isDisplayedColumn
     showedManager: {
       type: Function,
@@ -135,7 +139,8 @@ export default defineComponent({
       }
       */
       // get fields not mandatory
-      return store.getters.getFieldsListNotMandatory({
+      return props.fieldsToHidden({
+        parentUuid: props.parentUuid,
         containerUuid: props.containerUuid,
         fieldsList: props.fieldsList,
         showedMethod: props.showedManager,
@@ -145,7 +150,8 @@ export default defineComponent({
 
     const fieldsListAvailableWithValue = computed(() => {
       // get fields not mandatory with default value
-      return store.getters.getFieldsListNotMandatory({
+      return props.fieldsToHidden({
+        parentUuid: props.parentUuid,
         containerUuid: props.containerUuid,
         fieldsList: fieldsListAvailable.value,
         isEvaluateDefaultValue: true,

--- a/components/ADempiere/PanelDefinition/StandardPanel.vue
+++ b/components/ADempiere/PanelDefinition/StandardPanel.vue
@@ -31,6 +31,7 @@
             :fields-list="fieldsList"
             :filter-manager="containerManager.changeFieldShowedFromUser"
             :showed-manager="containerManager.isDisplayedField"
+            :fields-to-hidden="containerManager.getFieldsToHidden"
           />
 
           <el-card


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window.
2. Open any report/process.
3. Open any smart browser.

#### Screenshot or Gif


#### Link to minimal reproduction


https://user-images.githubusercontent.com/20288327/175565344-d4643c59-49c4-40c1-a049-6ec095ae2921.mp4



#### Expected behavior
* Window: By default only mandatory fields and no default value should be displayed.
* Process: By default, only mandatory fields or fields with default value should be displayed.
* Report: By default, only mandatory fields or fields with default value should be displayed.
* Smart Browser: By default, only mandatory fields or fields with default value should be displayed.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

