### PR TITLE
fix: Refresh page with enter key.

### DIFF
--- a/components/ADempiere/Field/FieldOptions/PreferenceValue/index.vue
+++ b/components/ADempiere/Field/FieldOptions/PreferenceValue/index.vue
@@ -56,6 +56,7 @@
         :inline="true"
         class="form-values"
         size="medium"
+        @submit.native.prevent="notSubmitForm"
       >
         <el-row>
           <el-col

--- a/components/ADempiere/Form/VMatch/components/Receipt/index.vue
+++ b/components/ADempiere/Form/VMatch/components/Receipt/index.vue
@@ -48,7 +48,12 @@
         />
       </el-tab-pane>
     </el-tabs>
-    <el-form :inline="true" label-position="top" class="demo-form-inline">
+    <el-form
+      :inline="true"
+      label-position="top"
+      class="demo-form-inline"
+      @submit.native.prevent="notSubmitForm"
+    >
       <template
         v-for="(item, index) in field"
       >
@@ -61,13 +66,19 @@
 </template>
 
 <script>
+// components and mixins
 import tableFrom from '../tableFrom'
+
+// constants
 import labelTable from '@theme/components/ADempiere/Form/VMatch/labelTable.js'
+
 export default {
-  name: 'Receipt',
+  name: 'VMatchReceipt',
+
   components: {
     tableFrom
   },
+
   data() {
     return {
       labelTable,

--- a/components/ADempiere/Form/VMatch/components/SearchCriteria/index.vue
+++ b/components/ADempiere/Form/VMatch/components/SearchCriteria/index.vue
@@ -14,7 +14,12 @@
  along with this program.  If not, see <https:www.gnu.org/licenses/>.
 -->
 <template>
-  <el-form v-if="!isEmptyValue(metadata)" label-position="top" class="from-main">
+  <el-form
+    v-if="!isEmptyValue(metadata)"
+    label-position="top"
+    class="from-main"
+    @submit.native.prevent="notSubmitForm"
+  >
     <el-form-item>
       <el-row>
         <el-col v-for="(field, index) in metadata" :key="index" :span="6">
@@ -34,9 +39,11 @@ import Field from '@theme/components/ADempiere/Field'
 
 export default {
   name: 'SearchCriteria',
+
   components: {
     Field
   },
+
   props: {
     metadata: {
       type: Array,

--- a/components/ADempiere/Form/VPOS/BusinessPartner/AddNewFieldLocation/locationAddressForm.vue
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/AddNewFieldLocation/locationAddressForm.vue
@@ -24,6 +24,7 @@
       size="small"
       class="location-address"
       @shortkey.native="keyAction"
+      @submit.native.prevent="notSubmitForm"
     >
       <el-row :gutter="0">
         <template v-if="isLoaded">

--- a/components/ADempiere/Form/VPOS/BusinessPartner/BillingFieldLocation/locationAddressForm.vue
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/BillingFieldLocation/locationAddressForm.vue
@@ -24,6 +24,7 @@
       size="small"
       class="location-address"
       @shortkey.native="keyAction"
+      @submit.native.prevent="notSubmitForm"
     >
       <el-row :gutter="0">
         <template v-if="isLoaded">

--- a/components/ADempiere/Form/VPOS/BusinessPartner/billingAddressFieldLocation/locationAddressForm.vue
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/billingAddressFieldLocation/locationAddressForm.vue
@@ -24,6 +24,7 @@
       size="small"
       class="location-address"
       @shortkey.native="keyAction"
+      @submit.native.prevent="notSubmitForm"
     >
       <el-row :gutter="24">
         <template v-if="isLoaded">

--- a/components/ADempiere/Form/VPOS/BusinessPartner/businessPartnerCreate.vue
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/businessPartnerCreate.vue
@@ -27,6 +27,7 @@
         label-position="top"
         size="small"
         class="create-bp"
+        @submit.native.prevent="notSubmitForm"
       >
         <el-row :gutter="24">
           <el-col :span="24">

--- a/components/ADempiere/Form/VPOS/BusinessPartner/businessPartnerUpdate.vue
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/businessPartnerUpdate.vue
@@ -26,6 +26,7 @@
       label-position="top"
       size="small"
       class="create-bp"
+      @submit.native.prevent="notSubmitForm"
     >
       <el-row :gutter="24">
         <el-col :span="24">

--- a/components/ADempiere/Form/VPOS/BusinessPartner/businessPartnersList.vue
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/businessPartnersList.vue
@@ -33,6 +33,7 @@
         <el-form
           label-position="top"
           size="small"
+          @submit.native.prevent="notSubmitForm"
         >
           <el-row>
             <field-definition

--- a/components/ADempiere/Form/VPOS/BusinessPartner/shippingAddressFieldLocation/locationAddressForm.vue
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/shippingAddressFieldLocation/locationAddressForm.vue
@@ -24,6 +24,7 @@
       size="small"
       class="location-address"
       @shortkey.native="keyAction"
+      @submit.native.prevent="notSubmitForm"
     >
       <el-row :gutter="24">
         <template v-if="isLoaded">

--- a/components/ADempiere/Form/VPOS/BusinessPartner/shippingFieldLocation/locationAddressForm.vue
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/shippingFieldLocation/locationAddressForm.vue
@@ -24,6 +24,7 @@
       size="small"
       class="location-address"
       @shortkey.native="keyAction"
+      @submit.native.prevent="notSubmitForm"
     >
       <el-row :gutter="0">
         <template v-if="isLoaded">

--- a/components/ADempiere/Form/VPOS/Collection/convertAmount/index.vue
+++ b/components/ADempiere/Form/VPOS/Collection/convertAmount/index.vue
@@ -32,6 +32,7 @@
             label-position="top"
             label-width="10px"
             style="float: right; display: flex; line-height: 10px;"
+            @submit.native.prevent="notSubmitForm"
           >
             <el-form-item :label="$t('form.pos.collect.Currency')">
               <el-select

--- a/components/ADempiere/Form/VPOS/Collection/index.vue
+++ b/components/ADempiere/Form/VPOS/Collection/index.vue
@@ -40,6 +40,7 @@
                 label-width="10px"
                 style="float: right; display: flex; line-height: 10px;"
                 :disabled="validateOpenAmount"
+                @submit.native.prevent="notSubmitForm"
               >
                 <el-row id="fieldListCollection">
                   <el-col

--- a/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/index.vue
+++ b/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/index.vue
@@ -28,7 +28,7 @@
       @close="close"
     >
       <div v-if="caseOrder === 1">
-        <el-form>
+        <el-form @submit.native.prevent="notSubmitForm">
           <el-form-item>
             <el-radio v-model="option" :label="1"> {{ $t('form.pos.collect.overdrawnInvoice.returned') }} {{ formatPrice(currentOrder.refundAmount, currency.iSOCode) }} </el-radio>
             <el-radio v-model="option" :label="3"> {{ $t('form.pos.collect.overdrawnInvoice.returnMoney') }}</el-radio>
@@ -57,6 +57,7 @@
               label-width="10px"
               style="display: flex; line-height: 10px;"
               :disabled="isDisabled"
+              @submit.native.prevent="notSubmitForm"
             >
               <el-row id="fieldListCollection">
                 <el-col
@@ -164,6 +165,7 @@
             <el-form
               label-position="top"
               label-width="10px"
+              @submit.native.prevent="notSubmitForm"
             >
               <el-row>
                 <el-col
@@ -212,6 +214,7 @@
               label-width="10px"
               style="display: flex; line-height: 10px;"
               :disabled="isDisabled"
+              @submit.native.prevent="notSubmitForm"
             >
               <el-row id="fieldListCollection">
                 <el-col

--- a/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/paymentTypeChange/ACH/index.vue
+++ b/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/paymentTypeChange/ACH/index.vue
@@ -20,6 +20,7 @@
     <el-form
       label-position="top"
       label-width="10px"
+      @submit.native.prevent="notSubmitForm"
     >
       <el-row :gutter="12">
         <el-col

--- a/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/paymentTypeChange/Cash/index.vue
+++ b/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/paymentTypeChange/Cash/index.vue
@@ -26,6 +26,7 @@
     <el-form
       label-position="top"
       label-width="10px"
+      @submit.native.prevent="notSubmitForm"
     >
       <el-row :gutter="12">
         <el-col

--- a/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/paymentTypeChange/GiftCards/index.vue
+++ b/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/paymentTypeChange/GiftCards/index.vue
@@ -20,6 +20,7 @@
     <el-form
       label-position="top"
       label-width="10px"
+      @submit.native.prevent="notSubmitForm"
     >
       <el-row :gutter="12">
         <el-col

--- a/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/paymentTypeChange/MobilePayment/index.vue
+++ b/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/paymentTypeChange/MobilePayment/index.vue
@@ -20,6 +20,7 @@
     <el-form
       label-position="top"
       label-width="10px"
+      @submit.native.prevent="notSubmitForm"
     >
       <el-row :gutter="12">
         <el-col

--- a/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/paymentTypeChange/Zelle/index.vue
+++ b/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/paymentTypeChange/Zelle/index.vue
@@ -20,6 +20,7 @@
     <el-form
       label-position="top"
       label-width="10px"
+      @submit.native.prevent="notSubmitForm"
     >
       <el-row :gutter="12">
         <el-col

--- a/components/ADempiere/Form/VPOS/ConfirmDelivery/index.vue
+++ b/components/ADempiere/Form/VPOS/ConfirmDelivery/index.vue
@@ -110,6 +110,7 @@
             <el-form
               label-position="top"
               :style="currentLineInfo === scope.row.uuid ? 'float: right;display: contents;line-height: 30px;' : 'float: right;display: none;line-height: 30px;'"
+              @submit.native.prevent="notSubmitForm"
             >
               <el-row style="margin: 10px!important;">
                 <el-col :span="6">

--- a/components/ADempiere/Form/VPOS/Options/CashOpening/index.vue
+++ b/components/ADempiere/Form/VPOS/Options/CashOpening/index.vue
@@ -27,6 +27,7 @@
           <el-form
             label-position="top"
             label-width="10px"
+            @submit.native.prevent="notSubmitForm"
           >
             <el-row id="fieldListCollection">
               <el-col
@@ -171,6 +172,7 @@
                 <el-form
                   label-position="top"
                   label-width="10px"
+                  @submit.native.prevent="notSubmitForm"
                 >
                   <el-row id="fieldListCollection">
                     <el-col

--- a/components/ADempiere/Form/VPOS/Options/Cashwithdrawal/index.vue
+++ b/components/ADempiere/Form/VPOS/Options/Cashwithdrawal/index.vue
@@ -27,6 +27,7 @@
           <el-form
             label-position="top"
             label-width="10px"
+            @submit.native.prevent="notSubmitForm"
           >
             <el-row id="fieldListCollection">
               <el-col
@@ -169,6 +170,7 @@
                 <el-form
                   label-position="top"
                   label-width="10px"
+                  @submit.native.prevent="notSubmitForm"
                 >
                   <el-row id="fieldListCollection">
                     <el-col

--- a/components/ADempiere/Form/VPOS/Order/index.vue
+++ b/components/ADempiere/Form/VPOS/Order/index.vue
@@ -143,6 +143,7 @@
                     <el-form
                       label-position="top"
                       style="float: right;display: contents;line-height: 30px;"
+                      @submit.native.prevent="notSubmitForm"
                     >
                       <el-row style="margin: 10px!important;">
                         <el-col :span="5">

--- a/components/ADempiere/Panel/mainPanelDesktop.vue
+++ b/components/ADempiere/Panel/mainPanelDesktop.vue
@@ -23,6 +23,7 @@
       v-model="dataRecords"
       label-position="top"
       label-width="200px"
+      @submit.native.prevent="notSubmitForm"
     >
       <template
         v-if="firstGroup && firstGroup.groupFinal === ''"
@@ -137,15 +138,21 @@
 </template>
 
 <script>
+// components and mixins
+import Draggable from 'vuedraggable'
 import mainPanelMixin from './mainPanelMixin.js'
-import draggable from 'vuedraggable'
 
 export default {
   name: 'MainPanelDesktop',
+
   components: {
-    draggable
+    Draggable
   },
-  mixins: [mainPanelMixin],
+
+  mixins: [
+    mainPanelMixin
+  ],
+
   methods: {
     setData(dataTransfer) {
       // to avoid Firefox bug

--- a/components/ADempiere/Panel/mainPanelMobile.vue
+++ b/components/ADempiere/Panel/mainPanelMobile.vue
@@ -23,6 +23,7 @@
       v-model="dataRecords"
       label-position="top"
       label-width="200px"
+      @submit.native.prevent="notSubmitForm"
     >
       <template
         v-if="firstGroup && firstGroup.groupFinal === ''"

--- a/components/ADempiere/PanelDefinition/StandardPanel.vue
+++ b/components/ADempiere/PanelDefinition/StandardPanel.vue
@@ -21,6 +21,7 @@
     <el-form
       label-position="top"
       label-width="200px"
+      @submit.native.prevent="notSubmitForm"
     >
       <div class="cards-not-group">
         <div class="card">
@@ -60,6 +61,7 @@
 
 <script>
 import { defineComponent, ref, computed, watch } from '@vue/composition-api'
+
 import store from '@/store'
 
 // components and mixins


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Business Partner` window.
2. Open `Bank Account` tab.
3. Select `New` button.
4. Fill `Name` field and press `enter` key.

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/176481667-2c7214fa-48db-4e54-abde-5e208007ad56.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/176482078-4794c739-56c4-416c-847f-b1e01c82fd7f.mp4


#### Expected behavior

The browser page should not refresh when the enter key is pressed on a field.


#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

