### PR TITLE
fix: Delete record with other client.

### DIFF
--- a/components/ADempiere/TabManager/convenienceButtons.vue
+++ b/components/ADempiere/TabManager/convenienceButtons.vue
@@ -53,7 +53,12 @@
         <el-button size="mini" type="text" @click="isVisibleConfirmDelete = false">
           {{ $t('window.cancel') }}
         </el-button>
-        <el-button type="primary" size="mini" @click="deleteCurrentRecord()">
+        <el-button
+          ref="buttonConfirmDelete"
+          type="primary"
+          size="mini"
+          @click="deleteCurrentRecord()"
+        >
           {{ $t('window.confirm') }}
         </el-button>
       </div>
@@ -64,6 +69,7 @@
         size="small"
         type="danger"
         class="delete-record-button"
+        @click="focusConfirmDelete()"
       >
         {{ $t('actionMenu.delete') }}
       </el-button>
@@ -83,6 +89,7 @@
 </template>
 
 <script>
+import Vue from 'vue'
 import { defineComponent, computed, onUnmounted, ref } from '@vue/composition-api'
 
 import store from '@/store'
@@ -123,6 +130,7 @@ export default defineComponent({
   setup(props) {
     const containerUuid = props.tabAttributes.uuid
     const isVisibleConfirmDelete = ref(false)
+    const buttonConfirmDelete = ref(null)
 
     const recordUuid = computed(() => {
       return store.getters.getUuidOfContainer(containerUuid)
@@ -147,10 +155,12 @@ export default defineComponent({
       if (isSecondaryParentTab.value) {
         return false
       }
-      if (props.tabAttributes.isDeleteable) {
-        return !isEmptyValue(recordUuid.value) && recordUuid.value !== 'create-new'
-      }
-      return false
+
+      // is enbaled delete on panel
+      return deleteRecord.enabled({
+        parentUuid: props.parentUuid,
+        containerUuid,
+      })
     })
 
     const isUndoChanges = computed(() => {
@@ -180,6 +190,15 @@ export default defineComponent({
           attributeValue: false,
           parentUuid: props.parentUuid,
           containerUuid: props.tabAttributes.uuid
+        })
+      }
+    }
+
+    function focusConfirmDelete() {
+      if (buttonConfirmDelete.value) {
+        Vue.nextTick(() => {
+          // doesn't work
+          // buttonConfirmDelete.value.$el.focus()
         })
       }
     }
@@ -220,6 +239,7 @@ export default defineComponent({
     })
 
     return {
+      buttonConfirmDelete,
       isVisibleConfirmDelete,
       // computed
       recordUuid,
@@ -230,6 +250,7 @@ export default defineComponent({
       // methods
       newRecord,
       deleteCurrentRecord,
+      focusConfirmDelete,
       undoChanges
     }
   }

--- a/components/ADempiere/TabManager/convenienceButtons.vue
+++ b/components/ADempiere/TabManager/convenienceButtons.vue
@@ -197,7 +197,7 @@ export default defineComponent({
     function focusConfirmDelete() {
       if (buttonConfirmDelete.value) {
         Vue.nextTick(() => {
-          // doesn't work
+          // TODO: Doesn't work, focus confirm button with displayed popover.
           // buttonConfirmDelete.value.$el.focus()
         })
       }


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with `GardenAdmin`.
2. Open any window with `System` client records.
3. Show `Client` field.
4. Delete record with `System` client.

#### Screenshot or Gif

Before this changes

https://user-images.githubusercontent.com/20288327/176515745-13c4d21a-6eed-4b8d-b748-57bec1fa8896.mp4

After this changes

https://user-images.githubusercontent.com/20288327/176515359-d4126c51-d188-430b-a625-c666dc236fbc.mp4


#### Expected behavior
It should not allow deleting records from another client, in this case it is hidden from the convenience buttons and disabled from the actions menu.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.
