### PR TITLE
feat: New/Undo without server request.

### DIFF
--- a/components/ADempiere/DefaultTable/index.vue
+++ b/components/ADempiere/DefaultTable/index.vue
@@ -54,6 +54,7 @@
         </el-button>
       </el-col>
     </el-row>
+
     <el-table
       id="multipleTable"
       ref="multipleTable"

--- a/components/ADempiere/TabManager/TabPanel.vue
+++ b/components/ADempiere/TabManager/TabPanel.vue
@@ -199,7 +199,9 @@ export default defineComponent({
 
     // get records list
     const recordsList = computed(() => {
-      return tabData.value.recordsList
+      return props.containerManager.getRecordsList({
+        containerUuid: props.tabAttributes.uuid
+      })
     })
 
     const currentPage = computed(() => {
@@ -218,12 +220,6 @@ export default defineComponent({
         })
       }
       return 0
-    })
-
-    const listRecord = computed(() => {
-      return props.containerManager.getRecordsList({
-        containerUuid: props.tabAttributes.uuid
-      })
     })
 
     const selectionsLength = computed(() => {
@@ -320,7 +316,6 @@ export default defineComponent({
       // Pagination
       currentPage,
       recordsLength,
-      listRecord,
       selectionsLength,
       // methodo
       changeFullScreen,

--- a/components/ADempiere/TabManager/index.vue
+++ b/components/ADempiere/TabManager/index.vue
@@ -33,8 +33,8 @@
     </auxiliary-panel> -->
     <div style="display: flex;height: 100%;">
       <el-tabs
-        v-model="currentTab"
         ref="el-tabs-container"
+        v-model="currentTab"
         class="el-tabs-container"
         type="border-card"
         style="width:100%"


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Business Partner` window.
2. Select `Bank Account` tab.
3. Create a record.
4. Select `New` button in `Business Partner` tab.
5. Select `Undo` button in `Business Partner` tab.


#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/177384921-b1b089cd-fe66-4888-a51a-4800a0e0d031.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/177384952-08492655-b7af-486e-9848-eea7f3044d48.mp4


#### Expected behavior
It is expected that undoing the changes will set the previous record and not request the child tabs to set the records that were there before.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

Fixes: https://github.com/solop-develop/frontend-core/issues/245