### PR TITLE
fix: Focus field on window without input field.

### DIFF
--- a/components/ADempiere/Field/index.vue
+++ b/components/ADempiere/Field/index.vue
@@ -364,7 +364,9 @@ export default {
     focusField(columnName) {
       setTimeout(() => {
         if (!this.isMobile && this.field.columnName === columnName && !isEmptyValue(this.$refs)) {
-          this.$refs[columnName].$refs[columnName].focus()
+          if (this.$refs[columnName] && this.$refs[columnName].$refs && this.$refs[columnName].$refs[columnName]) {
+            this.$refs[columnName].$refs[columnName].focus()
+          }
         }
       }, 1000)
     }


### PR DESCRIPTION

#### Steps to reproduce
1. Open `Business Partner` window.
2. Select `Location` tab.
3. Open web browser console.

Before this changes

https://user-images.githubusercontent.com/20288327/177848944-aa4132fb-b977-41ba-ac17-2f948804038c.mp4

After this changes

https://user-images.githubusercontent.com/20288327/177849029-dbece472-6cd6-4ed3-934c-5fd44ee03315.mp4

#### Additional context
This occurs when opening any window without text input fields displayed by default.
