### PR TITLE
feat: Replace includes to startsWith and endsWith.

### DIFF
--- a/components/ADempiere/Field/FieldLocation/locationAddressForm.vue
+++ b/components/ADempiere/Field/FieldLocation/locationAddressForm.vue
@@ -80,6 +80,7 @@ import { LOCATION_ADDRESS_FORM } from '@/utils/ADempiere/constants/location.js'
 
 // constants
 import FieldsList from './fieldsList.js'
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
 
 // api request methods
 import {
@@ -321,7 +322,7 @@ export default {
       const attributesToServer = attributesList
         .filter(attributeItem => {
           const { columnName } = attributeItem
-          if (columnName.includes('DisplayColumn_') || columnName === 'C_Location_ID') {
+          if (columnName.startsWith(DISPLAY_COLUMN_PREFIX) || columnName === 'C_Location_ID') {
             return false
           }
           return true

--- a/components/ADempiere/Field/FieldLocation/mixinLocation.js
+++ b/components/ADempiere/Field/FieldLocation/mixinLocation.js
@@ -20,6 +20,7 @@ import { getLocationAddress } from '@/api/ADempiere/field/location.js'
 // constants
 import { LOCATION_ADDRESS_FORM } from '@/utils/ADempiere/constants/location.js'
 import FieldsList from './fieldsList.js'
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils.js'
 
 // utils and helpers methods
 import { getSequenceAsList } from '@/utils/ADempiere/location'
@@ -128,7 +129,7 @@ export default {
 
       newFieldsList.forEach(field => {
         const { columnName } = field
-        const displayColumnName = `DisplayColumn_${columnName}`
+        const displayColumnName = DISPLAY_COLUMN_PREFIX + columnName
 
         let currrentValue = ''
         if (!this.isEmptyValue(entityValues[displayColumnName])) {

--- a/components/ADempiere/Field/FieldOptions/OperatorComparison/index.vue
+++ b/components/ADempiere/Field/FieldOptions/OperatorComparison/index.vue
@@ -39,6 +39,14 @@
 <script>
 import { computed, defineComponent, ref } from '@vue/composition-api'
 
+import store from '@/store'
+
+// constants
+import { OPERATORS_MULTIPLE_VALUES } from '@/utils/ADempiere/dataUtils'
+
+// utils and helper methods
+import { isEmptyValue } from '@/utils/ADempiere'
+
 export default defineComponent({
   name: 'OperatorComparisonField',
 
@@ -49,14 +57,14 @@ export default defineComponent({
     }
   },
 
-  setup(props, { root }) {
+  setup(props) {
+    const { parentUuid, containerUuid, columnName } = props.fieldAttributes
+
     const operatorsList = ref(props.fieldAttributes.operatorsList)
 
     const currentOperator = computed({
       get() {
-        const { columnName, containerUuid } = props.fieldAttributes
-
-        const { operator } = root.$store.getters.getFieldFromColumnName({
+        const { operator } = store.getters.getFieldFromColumnName({
           containerUuid,
           columnName
         })
@@ -64,9 +72,7 @@ export default defineComponent({
         return operator
       },
       set(newValue) {
-        const { columnName, containerUuid } = props.fieldAttributes
-
-        root.$store.dispatch('changeFieldAttribure', {
+        store.dispatch('changeFieldAttribure', {
           containerUuid,
           columnName,
           attributeName: 'operator',
@@ -76,10 +82,8 @@ export default defineComponent({
     })
 
     const fieldValue = computed(() => {
-      const { columnName, containerUuid, parentUuid } = props.fieldAttributes
-
       // main panel values
-      return root.$store.getters.getValueOfFieldOnContainer({
+      return store.getters.getValueOfFieldOnContainer({
         parentUuid,
         containerUuid,
         columnName
@@ -90,9 +94,7 @@ export default defineComponent({
      * @param {mixed} value, main value in component
      */
     const handleChange = (value) => {
-      const { columnName, containerUuid } = props.fieldAttributes
-
-      root.$store.dispatch('notifyFieldChange', {
+      store.dispatch('notifyFieldChange', {
         containerUuid,
         field: props.fieldAttributes,
         columnName,
@@ -105,8 +107,7 @@ export default defineComponent({
      */
     const changeOperator = (operatorValue) => {
       const value = fieldValue.value
-      if (!root.isEmptyValue(value) ||
-        ['NULL', 'NOT_NULL'].includes(operatorValue)) {
+      if (!isEmptyValue(value) || OPERATORS_MULTIPLE_VALUES.includes(operatorValue)) {
         handleChange(value)
       }
     }

--- a/components/ADempiere/Field/index.vue
+++ b/components/ADempiere/Field/index.vue
@@ -74,6 +74,7 @@ import store from '@/store'
 // constants
 import { UUID } from '@/utils/ADempiere/constants/systemColumns'
 import { TEXT, DEFAULT_SIZE } from '@/utils/ADempiere/references'
+import { OPERATORS_MULTIPLE_VALUES } from '@/utils/ADempiere/dataUtils'
 import { LAYOUT_MAX_COLUMNS_PER_ROW, DEFAULT_COLUMNS_PER_ROW } from '@/utils/ADempiere/componentUtils'
 import { LOCATION_ADDRESS_FORM } from '@/utils/ADempiere/constants/location.js'
 
@@ -313,7 +314,7 @@ export default {
 
     isSelectCreated() {
       return this.isAdvancedQuery &&
-        ['IN', 'NOT_IN'].includes(this.field.operator) &&
+        OPERATORS_MULTIPLE_VALUES.includes(this.field.operator) &&
         !['FieldBinary', 'FieldDate', 'FieldSelect', 'FieldYesNo'].includes(this.field.componentPath)
     },
     getWidth() {

--- a/components/ADempiere/Field/mixin/mixinFieldSelect.js
+++ b/components/ADempiere/Field/mixin/mixinFieldSelect.js
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+// constants
+import { OPERATORS_MULTIPLE_VALUES } from '@/utils/ADempiere/dataUtils'
+
 // utils and helper methods
 import { convertBooleanToString } from '@/utils/ADempiere/formatValue/booleanFormat.js'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
@@ -32,7 +35,8 @@ export default {
 
   computed: {
     isSelectMultiple() {
-      return ['IN', 'NOT_IN'].includes(this.metadata.operator) && this.metadata.isAdvancedQuery
+      return this.metadata.isAdvancedQuery &&
+        OPERATORS_MULTIPLE_VALUES.includes(this.metadata.operator)
     },
 
     blankOption() {

--- a/components/ADempiere/Form/ProductInfo/productList.vue
+++ b/components/ADempiere/Form/ProductInfo/productList.vue
@@ -157,6 +157,7 @@ import CustomPagination from '@theme/components/ADempiere/DefaultTable/CustomPag
 
 // constants
 import fieldsListProductPrice from './fieldsList.js'
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
 
 // utils and herlper methods
 import { formatPrice, formatQuantity } from '@/utils/ADempiere/valueFormat.js'
@@ -421,7 +422,7 @@ export default {
         //   this.setCurrent(this.listWithPrice[0])
         // }
         if (mutation.type === 'updateValueOfField' &&
-          !mutation.payload.columnName.includes('DisplayColumn') &&
+          !mutation.payload.columnName.startsWith(DISPLAY_COLUMN_PREFIX) &&
           mutation.payload.containerUuid === this.metadata.containerUuid) {
           clearTimeout(this.timeOut)
           this.timeOut = setTimeout(() => {

--- a/components/ADempiere/Form/VPOS/BusinessPartner/AddNewFieldLocation/locationAddressForm.vue
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/AddNewFieldLocation/locationAddressForm.vue
@@ -84,6 +84,7 @@ import mixinLocation from './mixinLocation.js'
 
 // constants
 import FieldsList from './fieldsList.js'
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
 
 // api request methods
 import {
@@ -321,7 +322,7 @@ export default {
       const attributesToServer = attributesList
         .filter(attributeItem => {
           const { columnName } = attributeItem
-          if (columnName.includes('DisplayColumn_') || columnName === 'C_Location_ID') {
+          if (columnName.startsWith(DISPLAY_COLUMN_PREFIX) || columnName === 'C_Location_ID') {
             return false
           }
           return true

--- a/components/ADempiere/Form/VPOS/BusinessPartner/AddNewFieldLocation/mixinLocation.js
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/AddNewFieldLocation/mixinLocation.js
@@ -19,6 +19,7 @@ import { getLocationAddress } from '@/api/ADempiere/field/location.js'
 
 // constants
 import FieldsList from './fieldsList.js'
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
 
 // utils and helpers methods
 import { getSequenceAsList } from '@/utils/ADempiere/location'
@@ -143,7 +144,7 @@ export default {
 
       newFieldsList.forEach(field => {
         const { columnName } = field
-        const displayColumnName = `DisplayColumn_${columnName}`
+        const displayColumnName = DISPLAY_COLUMN_PREFIX + columnName
 
         let currrentValue = ''
         if (!this.isEmptyValue(entityValues[displayColumnName])) {

--- a/components/ADempiere/Form/VPOS/BusinessPartner/BillingFieldLocation/locationAddressForm.vue
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/BillingFieldLocation/locationAddressForm.vue
@@ -67,6 +67,7 @@ import mixinLocation from './mixinLocation.js'
 
 // constants
 import FieldsList from './fieldsList.js'
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
 
 // api request methods
 import {
@@ -304,7 +305,7 @@ export default {
       const attributesToServer = attributesList
         .filter(attributeItem => {
           const { columnName } = attributeItem
-          if (columnName.includes('DisplayColumn_') || columnName === 'C_Location_ID') {
+          if (columnName.startsWith(DISPLAY_COLUMN_PREFIX) || columnName === 'C_Location_ID') {
             return false
           }
           return true

--- a/components/ADempiere/Form/VPOS/BusinessPartner/BillingFieldLocation/mixinLocation.js
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/BillingFieldLocation/mixinLocation.js
@@ -19,6 +19,7 @@ import { getLocationAddress } from '@/api/ADempiere/field/location.js'
 
 // constants
 import FieldsList from './fieldsList.js'
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils.js'
 
 // utils and helpers methods
 import { getSequenceAsList } from '@/utils/ADempiere/location'
@@ -143,7 +144,7 @@ export default {
 
       newFieldsList.forEach(field => {
         const { columnName } = field
-        const displayColumnName = `DisplayColumn_${columnName}`
+        const displayColumnName = DISPLAY_COLUMN_PREFIX + columnName
 
         let currrentValue = ''
         if (!this.isEmptyValue(entityValues[displayColumnName])) {

--- a/components/ADempiere/Form/VPOS/BusinessPartner/billingAddressFieldLocation/locationAddressForm.vue
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/billingAddressFieldLocation/locationAddressForm.vue
@@ -52,6 +52,7 @@
 <script>
 // constants
 import fieldsList from '@theme/components/ADempiere/Field/FieldLocation/fieldsList.js'
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
 
 // components and mixins
 import formMixin from '@theme/components/ADempiere/Form/formMixin.js'
@@ -279,7 +280,7 @@ export default {
       })
       const attributesToServer = attributes.filter(attributeItem => {
         const { columnName } = attributeItem
-        if (columnName.includes('DisplayColumn_')) {
+        if (columnName.startsWith(DISPLAY_COLUMN_PREFIX)) {
           return false
         }
         if (columnName === 'C_Location_ID') {

--- a/components/ADempiere/Form/VPOS/BusinessPartner/shippingAddressFieldLocation/locationAddressForm.vue
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/shippingAddressFieldLocation/locationAddressForm.vue
@@ -52,6 +52,7 @@
 <script>
 // constants
 import fieldsList from './fieldsList.js'
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
 
 // components and mixins
 import formMixin from '@theme/components/ADempiere/Form/formMixin.js'
@@ -279,7 +280,7 @@ export default {
       })
       const attributesToServer = attributes.filter(attributeItem => {
         const { columnName } = attributeItem
-        if (columnName.includes('DisplayColumn_')) {
+        if (columnName.startsWith(DISPLAY_COLUMN_PREFIX)) {
           return false
         }
         if (columnName === 'C_Location_ID') {

--- a/components/ADempiere/Form/VPOS/BusinessPartner/shippingFieldLocation/locationAddressForm.vue
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/shippingFieldLocation/locationAddressForm.vue
@@ -67,6 +67,7 @@ import mixinLocation from './mixinLocation.js'
 
 // constants
 import FieldsList from './fieldsList.js'
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
 
 // api request methods
 import {
@@ -301,7 +302,7 @@ export default {
       const attributesToServer = attributesList
         .filter(attributeItem => {
           const { columnName } = attributeItem
-          if (columnName.includes('DisplayColumn_') || columnName === 'C_Location_ID') {
+          if (columnName.startsWith(DISPLAY_COLUMN_PREFIX) || columnName === 'C_Location_ID') {
             return false
           }
           return true

--- a/components/ADempiere/Form/VPOS/BusinessPartner/shippingFieldLocation/mixinLocation.js
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/shippingFieldLocation/mixinLocation.js
@@ -19,6 +19,7 @@ import { getLocationAddress } from '@/api/ADempiere/field/location.js'
 
 // constants
 import FieldsList from './fieldsList.js'
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
 
 // utils and helpers methods
 import { getSequenceAsList } from '@/utils/ADempiere/location'
@@ -143,7 +144,7 @@ export default {
 
       newFieldsList.forEach(field => {
         const { columnName } = field
-        const displayColumnName = `DisplayColumn_${columnName}`
+        const displayColumnName = DISPLAY_COLUMN_PREFIX + columnName
 
         let currrentValue = ''
         if (!this.isEmptyValue(entityValues[displayColumnName])) {

--- a/components/ADempiere/Form/VPOS/OrderList/fastOrder.vue
+++ b/components/ADempiere/Form/VPOS/OrderList/fastOrder.vue
@@ -125,6 +125,7 @@
 <script>
 // constants
 import fieldsListOrders from './fieldsListOrders.js'
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
 
 // components and mixins
 import FindOrders from './FindOrders'
@@ -516,8 +517,8 @@ export default {
           if (payload.containerUuid === this.metadata.containerUuid) {
             const { columnName } = payload
 
-            if (!columnName.includes('DisplayColumn') &&
-              !columnName.includes('_UUID')) {
+            if (!columnName.startsWith(DISPLAY_COLUMN_PREFIX) &&
+              !columnName.endsWith('_UUID')) {
               clearTimeout(this.timeOut)
               this.timeOut = setTimeout(() => {
                 this.listOrdersInvoiced(this.currentOptions)

--- a/components/ADempiere/Form/VPOS/OrderList/index.vue
+++ b/components/ADempiere/Form/VPOS/OrderList/index.vue
@@ -265,6 +265,7 @@
 <script>
 // constants
 import fieldsListOrders from './fieldsListOrders.js'
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
 
 // components and mixins
 import DocumentStatusTag from '@theme/components/ADempiere/ContainerOptions/DocumentStatusTag/index.vue'
@@ -530,8 +531,8 @@ export default {
     subscribeChanges() {
       return this.$store.subscribe((mutation, state) => {
         if (mutation.type === 'updateValueOfField' &&
-          !mutation.payload.columnName.includes('DisplayColumn') &&
-          !mutation.payload.columnName.includes('_UUID') &&
+          !mutation.payload.columnName.startsWith(DISPLAY_COLUMN_PREFIX) &&
+          !mutation.payload.columnName.endsWith('_UUID') &&
           mutation.payload.containerUuid === this.metadata.containerUuid) {
           clearTimeout(this.timeOut)
           this.isLoadRecord = true

--- a/components/ADempiere/Form/VPOS/OrderList/searchCompleteOrders.vue
+++ b/components/ADempiere/Form/VPOS/OrderList/searchCompleteOrders.vue
@@ -134,6 +134,7 @@
 <script>
 // constants
 import fieldsListOrders from './fieldsListOrders.js'
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
 
 // components and mixins
 import DocumentStatusTag from '@theme/components/ADempiere/ContainerOptions/DocumentStatusTag/index.vue'
@@ -299,8 +300,8 @@ export default {
           this.dateOrdered = mutation.payload.value
         }
         if (mutation.type === 'updateValueOfField' &&
-          !mutation.payload.columnName.includes('DisplayColumn') &&
-          !mutation.payload.columnName.includes('_UUID') &&
+          !mutation.payload.columnName.startsWith(DISPLAY_COLUMN_PREFIX) &&
+          !mutation.payload.columnName.endsWith('_UUID') &&
           mutation.payload.containerUuid === this.metadata.containerUuid) {
           clearTimeout(this.timeOut)
           this.timeOut = setTimeout(() => {

--- a/components/ADempiere/Form/VPOS/OrderList/toDeliver.vue
+++ b/components/ADempiere/Form/VPOS/OrderList/toDeliver.vue
@@ -134,6 +134,7 @@
 <script>
 // constants
 import fieldsListOrders from './fieldsListOrders.js'
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils.js'
 
 // components and mixins
 import FieldDefinition from '@theme/components/ADempiere/Field/index.vue'
@@ -299,8 +300,8 @@ export default {
           this.dateOrdered = mutation.payload.value
         }
         if (mutation.type === 'updateValueOfField' &&
-          !mutation.payload.columnName.includes('DisplayColumn') &&
-          !mutation.payload.columnName.includes('_UUID') &&
+          !mutation.payload.columnName.startsWith(DISPLAY_COLUMN_PREFIX) &&
+          !mutation.payload.columnName.endsWith('_UUID') &&
           mutation.payload.containerUuid === this.metadata.containerUuid) {
           clearTimeout(this.timeOut)
           this.timeOut = setTimeout(() => {

--- a/components/ADempiere/TabManager/TabOptions.vue
+++ b/components/ADempiere/TabManager/TabOptions.vue
@@ -64,6 +64,9 @@ import store from '@/store'
 import ActionMenu from '@theme/components/ADempiere/ActionMenu/index.vue'
 import ConvenienceButtons from '@theme/components/ADempiere/TabManager/convenienceButtons.vue'
 
+// utils and helper methods
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
+
 export default defineComponent({
   name: 'TabOptions',
 

--- a/components/ADempiere/WorkflowStatusBar/index.vue
+++ b/components/ADempiere/WorkflowStatusBar/index.vue
@@ -78,6 +78,9 @@
 </template>
 
 <script>
+// constants
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
+
 // components and mixins
 import DocumentStatusTag from '@theme/components/ADempiere/ContainerOptions/DocumentStatusTag/index.vue'
 
@@ -116,7 +119,7 @@ export default {
       typeAction: 0,
       chatNote: '',
       columnName,
-      displayColumnName: `DisplayColumn_${columnName}`,
+      displayColumnName: DISPLAY_COLUMN_PREFIX + columnName,
       documentStatusesList: []
     }
   },


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

Improve performance by replacing the `includes` string function with the `startsWith` and `endsWith` functions as appropriate

Executions per second of the `includes` function (24,906,181) vs the `startsWith` function (32,053,102):

![Screenshot_20220708_203710](https://user-images.githubusercontent.com/20288327/178084980-db5f364c-19fe-4d42-bf31-32f10fa20b54.png)

Executions per second of the `includes` function (15,123,305) vs the `endsWith` function (17,257,294)

![Screenshot_20220708_203733](https://user-images.githubusercontent.com/20288327/178084977-1669e8a3-d11e-4798-8256-eb4c570e9ccf.png)

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
https://www.measurethat.net/Benchmarks/Show/5418/0/endswith-vs-includes

https://www.measurethat.net/Benchmarks/Show/9395/0/startswith-vs-includes

