### PR TITLE
feat: Refresh current entity.

### DIFF
--- a/components/ADempiere/TabManager/convenienceButtons.vue
+++ b/components/ADempiere/TabManager/convenienceButtons.vue
@@ -19,12 +19,12 @@
 <template>
   <div v-show="isDisDisableOptionsTabChild" class="convenience-buttons-main">
     <el-button
-      v-if="isCreateRecord"
+      v-if="isCreateRecord && !isExistsChanges"
       plain
       size="small"
       type="success"
       class="new-record-button"
-      @click="newRecord"
+      @click="newRecord()"
     >
       {{ $t('actionMenu.new') }}
     </el-button>
@@ -35,9 +35,20 @@
       size="small"
       type="info"
       class="undo-changes-button"
-      @click="undoChanges"
+      @click="undoChanges()"
     >
       {{ $t('actionMenu.undo') }}
+    </el-button>
+
+    <el-button
+      v-show="!isExistsChanges"
+      plain
+      size="small"
+      type="primary"
+      class="undo-changes-button"
+      @click="refreshCurrentRecord()"
+    >
+      {{ $t('actionMenu.refresh') }}
     </el-button>
 
     <el-popover
@@ -92,7 +103,7 @@
       size="small"
       type="primary"
       class="undo-changes-button"
-      @click="saveChanges"
+      @click="saveChanges()"
     >
       {{ $t('actionMenu.save') }}
     </el-button>
@@ -115,7 +126,9 @@ import ActionMenu from '@theme/components/ADempiere/ActionMenu/index.vue'
 // utils and helper methods
 import { showMessage } from '@/utils/ADempiere/notification'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
-import { createNewRecord, deleteRecord, undoChange } from '@/utils/ADempiere/dictionary/window'
+import {
+  createNewRecord, refreshRecord, deleteRecord, undoChange
+} from '@/utils/ADempiere/dictionary/window'
 
 export default defineComponent({
   name: 'ConvenienceButtons',
@@ -266,6 +279,13 @@ export default defineComponent({
       }
     }
 
+    function refreshCurrentRecord() {
+      refreshRecord.refreshRecord({
+        parentUuid: props.parentUuid,
+        containerUuid
+      })
+    }
+
     function focusConfirmDelete() {
       if (buttonConfirmDelete.value) {
         Vue.nextTick(() => {
@@ -351,6 +371,7 @@ export default defineComponent({
       recordUuid,
       selectionsRecords,
       isCreateRecord,
+      isExistsChanges,
       isDeleteRecord,
       isUndoChanges,
       getCurrentTab,
@@ -362,6 +383,7 @@ export default defineComponent({
       newRecord,
       deleteCurrentRecord,
       focusConfirmDelete,
+      refreshCurrentRecord,
       undoChanges,
       saveChanges
     }


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window.
2. Create new record.
3. Show multi record.
4. Refresh record.

When creating a record, no display values are returned, however when updating the entity, it refreshes only the current record and sets the display values, without updating the entire list of records.

#### Screenshot or Gif


https://user-images.githubusercontent.com/20288327/178754514-6ec6b8c0-6a70-414e-a342-dbe194f6ef24.mp4


#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Depends on https://github.com/solop-develop/backend/pull/34
Depends on https://github.com/solop-develop/gRPC-API/pull/6
Depends on https://github.com/solop-develop/proxy-adempiere-api/pull/7
