### PR TITLE
fix: ReadOnly logic with call same field.

### DIFF
--- a/components/ADempiere/TabManager/convenienceButtons.vue
+++ b/components/ADempiere/TabManager/convenienceButtons.vue
@@ -17,7 +17,7 @@
 -->
 
 <template>
-  <div v-show="isDisDisableOptionsTabChild" class="convenience-buttons-main">
+  <div v-show="isDisableOptionsTabChild" class="convenience-buttons-main">
     <el-button
       v-if="isCreateRecord && !isExistsChanges"
       plain
@@ -176,7 +176,7 @@ export default defineComponent({
       return selectionsRecords.value
     })
 
-    const isDisDisableOptionsTabChild = computed(() => {
+    const isDisableOptionsTabChild = computed(() => {
       if (!getCurrentTab.value.isParentTab) {
         if (store.getters.getUuidOfContainer(getCurrentTab.value.firstTabUuid)) {
           return true
@@ -200,11 +200,12 @@ export default defineComponent({
       if (isSecondaryParentTab.value) {
         return false
       }
-      if (props.tabAttributes.isInsertRecord && !props.tabAttributes.isReadOnly) {
-        return !isEmptyValue(recordUuid.value) // && recordUuid.value !== 'create-new'
-      }
 
-      return false
+      return createNewRecord.enabled({
+        parentUuid: props.parentUuid,
+        tabParentIndex: props.tabAttributes.tabParentIndex,
+        containerUuid
+      })
     })
 
     const isExistsChanges = computed(() => {
@@ -375,7 +376,7 @@ export default defineComponent({
       isDeleteRecord,
       isUndoChanges,
       getCurrentTab,
-      isDisDisableOptionsTabChild,
+      isDisableOptionsTabChild,
       recordParentTab,
       isSaveRecord,
       listOfRecordsToDeleted,


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

A. Window as `Query` window type.
1. Login with `GardenAdmin`
2. Open `Account Combination` window.
3. Show all fields.

Note how the `Is Active` field allows the value to be changed, it should be disabled.

Before this changes:

https://user-images.githubusercontent.com/20288327/179030630-02cedc5c-47a5-483a-840b-c9dc7ee223fe.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/179030666-9a9485d5-d924-4540-9c99-52d79284994d.mp4


B. Field with read-only logic of its own column.
1. Login with `System`
2. Open `Element` window.
3. Show all fields.
4. Select a record with the entity type other than Dictionary.
5. Set the entity type to dictionary

You should set the field to read-only since it calls itself in the read-only logic `@EntityType@=D`.


Before this changes:

https://user-images.githubusercontent.com/20288327/179031528-0c3aea88-b0ac-4864-b346-53d1c5c3c5c8.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/179031625-590c68c5-7e9a-4a59-954f-ec23bc75aed5.mp4



#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes: https://github.com/solop-develop/frontend-core/issues/223
