### PR TITLE
feat: Add display logic on tab.

### DIFF
--- a/components/ADempiere/TabManager/TabOptions.vue
+++ b/components/ADempiere/TabManager/TabOptions.vue
@@ -63,8 +63,6 @@ import store from '@/store'
 // components and mixins
 import ActionMenu from '@theme/components/ADempiere/ActionMenu/index.vue'
 import ConvenienceButtons from '@theme/components/ADempiere/TabManager/convenienceButtons.vue'
-// utils and helper methods
-import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 
 // utils and helper methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'

--- a/components/ADempiere/TabManager/tabChild.vue
+++ b/components/ADempiere/TabManager/tabChild.vue
@@ -26,7 +26,7 @@
     @tab-click="handleClick"
   >
     <el-tab-pane
-      v-for="(tabAttributes, key) in tabsList"
+      v-for="(tabAttributes, key) in showedTabsList"
       :key="key"
       :label="tabAttributes.name"
       :name="String(key)"
@@ -182,6 +182,13 @@ export default defineComponent({
     // use getter to reactive properties
     const currentTabMetadata = computed(() => {
       return store.getters.getStoredTab(props.parentUuid, tabUuid.value)
+    })
+
+    // tabs with display logic
+    const showedTabsList = computed(() => {
+      return props.tabsList.filter(tab => {
+        return tab.isShowedTab()
+      })
     })
 
     const isShowedTabs = computed(() => {
@@ -447,6 +454,7 @@ export default defineComponent({
       storedOldContextAttibutes,
       currentContextAttributes,
       isShowedTabs,
+      showedTabsList,
       isMobile,
       listAction,
       currentTabMetadata,

--- a/components/ADempiere/TabManager/tabChild.vue
+++ b/components/ADempiere/TabManager/tabChild.vue
@@ -20,6 +20,7 @@
   <!-- <div style="height: 100% !important;">
     <div style="display: flex;"> -->
   <el-tabs
+    v-if="!isEmptyValue(showedTabsList)"
     v-model="currentTab"
     type="border-card"
     style="width: 100%"

--- a/components/ADempiere/TabManager/tabChild.vue
+++ b/components/ADempiere/TabManager/tabChild.vue
@@ -17,50 +17,72 @@
 -->
 
 <template>
-  <!-- <div style="height: 100% !important;">
-    <div style="display: flex;"> -->
-  <span v-if="!tabLoading">
-    <el-tabs
-      v-if="!isEmptyValue(showedTabsList)"
-      v-model="currentTab"
-      type="border-card"
-      style="width: 100%"
-      @tab-click="handleClick"
+  <el-tabs
+    v-if="!isEmptyValue(showedTabsList)"
+    v-model="currentTab"
+    type="border-card"
+    style="width: 100%"
+    @tab-click="handleClick"
+  >
+    <el-tab-pane
+      v-for="(tabAttributes, key) in showedTabsList"
+      :key="key"
+      :label="tabAttributes.name"
+      :name="String(key)"
+      :tabuuid="tabAttributes.uuid"
+      :tabindex="String(key)"
+      lazy
+      :disabled="isDisabledTab(key)"
+      :style="tabStyle"
     >
-      <el-tab-pane
-        v-for="(tabAttributes, key) in showedTabsList"
-        :key="key"
-        :label="tabAttributes.name"
-        :name="String(key)"
-        :tabuuid="tabAttributes.uuid"
-        :tabindex="String(key)"
-        lazy
-        :disabled="isDisabledTab(key)"
-        :style="tabStyle"
-      >
-        <tab-label
-          slot="label"
-          :is-active-tab="tabAttributes.uuid === tabUuid"
-          :parent-uuid="parentUuid"
-          :container-uuid="tabAttributes.uuid"
-        />
+      <tab-label
+        slot="label"
+        :is-active-tab="tabAttributes.uuid === tabUuid"
+        :parent-uuid="parentUuid"
+        :container-uuid="tabAttributes.uuid"
+      />
 
-        <div v-if="isShowedTableRecords">
-          <tab-options
+      <div v-if="isShowedTableRecords">
+        <tab-options
+          :parent-uuid="parentUuid"
+          :container-manager="containerManager"
+          :current-tab-uuid="tabUuid"
+          :tabs-list="tabsList"
+          :all-tabs-list="allTabsList"
+          :tab-attributes="tabAttributes"
+          :references-manager="referencesManager"
+        />
+        <br>
+      </div>
+
+      <div v-if="isShowedTabs">
+        <!-- records in table to multi records -->
+        <div v-if="isMobile">
+          <tab-panel
+            key="tab-panel"
             :parent-uuid="parentUuid"
             :container-manager="containerManager"
-            :current-tab-uuid="tabUuid"
             :tabs-list="tabsList"
             :all-tabs-list="allTabsList"
+            :current-tab-uuid="tabUuid"
             :tab-attributes="tabAttributes"
+            :actions-manager="actionsManager"
             :references-manager="referencesManager"
           />
-          <br>
         </div>
-
-        <div v-if="isShowedTabs">
-          <!-- records in table to multi records -->
-          <div v-if="isMobile">
+        <div v-else>
+          <default-table
+            v-if="isShowedTableRecords"
+            key="default-table"
+            :parent-uuid="parentUuid"
+            :container-uuid="tabAttributes.uuid"
+            :container-manager="containerManager"
+            :header="tableHeaders"
+            :data-table="recordsList"
+            :panel-metadata="tabAttributes"
+            :is-navigation="true"
+          />
+          <el-scrollbar v-else ref="tabPanel" :vertical="false" class="scroll-tab-panel">
             <tab-panel
               key="tab-panel"
               :parent-uuid="parentUuid"
@@ -72,41 +94,11 @@
               :actions-manager="actionsManager"
               :references-manager="referencesManager"
             />
-          </div>
-          <div v-else>
-            <default-table
-              v-if="isShowedTableRecords"
-              key="default-table"
-              :parent-uuid="parentUuid"
-              :container-uuid="tabAttributes.uuid"
-              :container-manager="containerManager"
-              :header="tableHeaders"
-              :data-table="recordsList"
-              :panel-metadata="tabAttributes"
-              :is-navigation="true"
-            />
-            <el-scrollbar v-else ref="tabPanel" :vertical="false" class="scroll-tab-panel">
-              <tab-panel
-                key="tab-panel"
-                :parent-uuid="parentUuid"
-                :container-manager="containerManager"
-                :tabs-list="tabsList"
-                :all-tabs-list="allTabsList"
-                :current-tab-uuid="tabUuid"
-                :tab-attributes="tabAttributes"
-                :actions-manager="actionsManager"
-                :references-manager="referencesManager"
-              />
-            </el-scrollbar>
-          </div>
+          </el-scrollbar>
         </div>
-      </el-tab-pane>
-    </el-tabs>
-  </span>
-  <loading-view
-    v-else
-    key="tab-loading"
-  />
+      </div>
+    </el-tab-pane>
+  </el-tabs>
 </template>
 
 <script>
@@ -122,7 +114,6 @@ import DefaultTable from '@theme/components/ADempiere/DefaultTable/index.vue'
 import TabLabel from '@theme/components/ADempiere/TabManager/TabLabel.vue'
 import TabPanel from './TabPanel.vue'
 import TabOptions from './TabOptions.vue'
-import LoadingView from '@theme/components/ADempiere/LoadingView/index.vue'
 
 // constants
 import { UUID } from '@/utils/ADempiere/constants/systemColumns.js'
@@ -139,8 +130,7 @@ export default defineComponent({
     DefaultTable,
     TabPanel,
     TabLabel,
-    TabOptions,
-    LoadingView
+    TabOptions
   },
 
   props: {
@@ -179,9 +169,6 @@ export default defineComponent({
     const currentTab = ref(tabNo)
 
     const tabUuid = ref(props.tabsList[tabNo].uuid)
-
-    const tabLoading = ref(false)
-    const timeOut = ref(() => {})
 
     const tabStyle = computed(() => {
       // height tab content
@@ -422,15 +409,6 @@ export default defineComponent({
     //   }
     // })
 
-    watch(showedTabsList, (newValue, oldValue) => {
-      if (newValue !== oldValue && !isEmptyValue(newValue)) {
-        tabLoading.value = true
-        timeOut.value = setTimeout(() => {
-          tabLoading.value = false
-        }, 100)
-      }
-    })
-
     // if changed record in parent tab, reload tab child
     watch(recordUuidTabParent, (newValue, oldValue) => {
       if (newValue !== oldValue && !isEmptyValue(newValue)) {
@@ -476,7 +454,6 @@ export default defineComponent({
       currentTab,
       tableHeaders,
       recordsList,
-      tabLoading,
       // computed
       storedOldRecord,
       storedOldContextAttibutes,


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Business Partner` window.
2. Select `Vendor` tab.
3. Change `Is Vendor` field.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/179060562-35c5cb17-9c8e-41ba-a2f1-180df50cff26.mp4

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
`Purchasing Product` tab has display logic `@IsVendor@='Y'`

Fixes https://github.com/solop-develop/frontend-core/issues/251
