### PR TITLE
fix: Undo changes, set correct values.

### DIFF
--- a/components/ADempiere/DefaultTable/index.vue
+++ b/components/ADempiere/DefaultTable/index.vue
@@ -485,8 +485,10 @@ export default defineComponent({
         props.containerUuid
       )
       if (!isEmptyValue(currentTab) && !currentTab.isParentTab) {
-        const records = store.getters.getTabCurrentRecord({ containerUuid: props.containerUuid })
-        return records
+        const record = store.getters.getTabCurrentRow({
+          containerUuid: props.containerUuid
+        })
+        return record
       }
       return {}
     })

--- a/components/ADempiere/TabManager/convenienceButtons.vue
+++ b/components/ADempiere/TabManager/convenienceButtons.vue
@@ -19,7 +19,7 @@
 <template>
   <div v-show="isDisableOptionsTabChild" class="convenience-buttons-main">
     <el-button
-      v-if="isCreateRecord && !isExistsChanges"
+      v-if="isCreateRecord"
       plain
       size="small"
       type="success"
@@ -30,7 +30,7 @@
     </el-button>
 
     <el-button
-      v-if="isUndoChanges || isSaveRecord"
+      v-if="isUndoChanges"
       plain
       size="small"
       type="info"
@@ -41,7 +41,7 @@
     </el-button>
 
     <el-button
-      v-show="!isExistsChanges"
+      v-show="isRefreshRecord"
       plain
       size="small"
       type="primary"
@@ -112,7 +112,7 @@
 
 <script>
 import Vue from 'vue'
-import { defineComponent, computed, onUnmounted, ref } from '@vue/composition-api'
+import { defineComponent, computed, ref } from '@vue/composition-api'
 
 import store from '@/store'
 import language from '@/lang'
@@ -170,8 +170,10 @@ export default defineComponent({
 
     const listOfRecordsToDeleted = computed(() => {
       if (!getCurrentTab.value.isShowedTableRecords) {
-        const records = store.getters.getTabCurrentRecord({ containerUuid })
-        return [records]
+        const record = store.getters.getTabCurrentRow({
+          containerUuid
+        })
+        return [record]
       }
       return selectionsRecords.value
     })
@@ -192,12 +194,15 @@ export default defineComponent({
 
     const selectionsRecords = computed(() => {
       return props.containerManager.getSelection({
-        containerUuid: props.tabAttributes.uuid
+        containerUuid
       })
     })
 
     const isCreateRecord = computed(() => {
       if (isSecondaryParentTab.value) {
+        return false
+      }
+      if (isExistsChanges.value) {
         return false
       }
 
@@ -209,11 +214,19 @@ export default defineComponent({
     })
 
     const isExistsChanges = computed(() => {
-      const persistenceValues = store.getters.getPersistenceAttributes({
+      const persistenceValues = store.getters.getPersistenceAttributesChanges({
+        parentUuid: props.parentUuid,
         containerUuid,
         recordUuid: recordUuid.value
       })
       return !isEmptyValue(persistenceValues)
+    })
+
+    const isRefreshRecord = computed(() => {
+      if (isEmptyValue(recordUuid.value)) {
+        return false
+      }
+      return !isExistsChanges.value
     })
 
     const emptyMandatoryFields = computed(() => {
@@ -250,13 +263,19 @@ export default defineComponent({
     })
 
     const isUndoChanges = computed(() => {
-      return isEmptyValue(recordUuid.value) || recordUuid.value === 'create-new'
+      if (!isEmptyValue(recordUuid.value)) {
+        return isExistsChanges.value
+      }
+
+      // without old record
+      const oldRecordUuid = store.getters.getCurrentRecordOnPanel(containerUuid)
+      return !isEmptyValue(oldRecordUuid) || isExistsChanges.value
     })
 
     const getCurrentTab = computed(() => {
       const tab = store.getters.getStoredTab(
         props.parentUuid,
-        props.tabAttributes.uuid
+        containerUuid
       )
       if (tab) {
         return tab
@@ -275,7 +294,7 @@ export default defineComponent({
           attributeNameControl: undefined,
           attributeValue: false,
           parentUuid: props.parentUuid,
-          containerUuid: props.tabAttributes.uuid
+          containerUuid
         })
       }
     }
@@ -300,7 +319,7 @@ export default defineComponent({
       if (getCurrentTab.value.isShowedTableRecords && !isEmptyValue(selectionsRecords.value)) {
         store.dispatch('deleteSelectedRecordsFromWindow', {
           parentUuid: props.parentUuid,
-          containerUuid: props.tabAttributes.uuid
+          containerUuid
         })
         isVisibleConfirmDelete.value = false
         return
@@ -350,7 +369,7 @@ export default defineComponent({
      * Vuex subscription when record parent change
      * TODO: Add support to restart or delete timer by flushPersistenceQueue
      */
-    const unsubscribeChangeParentRecord = () => {}
+    // const unsubscribeChangeParentRecord = () => {}
 
     // unsubscribeChangeParentRecord = store.subscribeAction({
     //   before: (action, state) => {
@@ -361,9 +380,9 @@ export default defineComponent({
     // })
 
     // remove susbscriptions
-    onUnmounted(() => {
-      unsubscribeChangeParentRecord()
-    })
+    // onUnmounted(() => {
+    //   unsubscribeChangeParentRecord()
+    // })
 
     return {
       buttonConfirmDelete,
@@ -374,6 +393,7 @@ export default defineComponent({
       isCreateRecord,
       isExistsChanges,
       isDeleteRecord,
+      isRefreshRecord,
       isUndoChanges,
       getCurrentTab,
       isDisableOptionsTabChild,


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window.
2. Set first record.
3. Change record.
4. Change to first record.
5. Change a value of field.
6. Click on `Undo` button.

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/179312646-50d2916e-aef7-44f6-822d-252298fcdee4.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/179312652-72b626d8-a0f6-4de9-8a45-a40311d91190.mp4

#### Expected behavior
If there is a change in the current record, just discard the changes and keep the same record, not change to the previously selected record.


#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes: https://github.com/solop-develop/frontend-core/issues/247
