### PR TITLE
feat: Support on Business Partner search field

### DIFF
--- a/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo/businessPartnersList.vue
+++ b/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo/businessPartnersList.vue
@@ -1,0 +1,441 @@
+<!--
+ ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https:www.gnu.org/licenses/>.
+-->
+
+<template>
+  <el-main
+    v-shortkey="shortsKey"
+    class="business-partners-list-container"
+    style="padding-top: 0px"
+    @shortkey.native="keyAction"
+  >
+    <el-collapse v-model="activeAccordion" accordion class="business-partners-query-criteria">
+      <el-collapse-item name="query-criteria">
+        <template slot="title">
+          {{ $t('form.pos.order.BusinessPartnerCreate.businessPartner') }}
+          <template v-if="!isEmptyValue(metadata.name) ">
+            ({{ metadata.name }})
+          </template>
+        </template>
+
+        <el-form
+          label-position="top"
+          size="small"
+          @submit.native.prevent="notSubmitForm"
+        >
+          <el-row>
+            <field-definition
+              v-for="(field) in metadataList"
+              :key="field.columnName"
+              :metadata-field="field"
+              :container-uuid="'Business-Partner-List'"
+              :container-manager="containerManagerBPList"
+            />
+          </el-row>
+        </el-form>
+      </el-collapse-item>
+    </el-collapse>
+
+    <el-table
+      ref="businessPartnerTable"
+      v-loading="isLoadingRecords"
+      class="business-partners-table"
+      :data="businessPartnersList"
+      highlight-current-row
+      border
+      fit
+      :max-height="300"
+      size="small"
+      @current-change="handleCurrentChange"
+      @row-dblclick="changeBusinessPartner"
+    >
+      <p slot="empty" style="width: 100%;">
+        {{ $t('businessPartner.emptyBusinessPartner') }}
+      </p>
+
+      <el-table-column
+        type="index"
+        label="#"
+        width="35"
+        header-align="center"
+      />
+
+      <el-table-column
+        v-for="(heard, key) in labelTable"
+        :key="key"
+        :label="heard.label"
+        prop="value"
+        header-align="center"
+      >
+        <span v-if="heard.columnName === 'Value'" slot-scope="scope">
+          {{ scope.row.value }}
+        </span>
+        <span v-else-if="heard.columnName === 'TaxID'" slot-scope="scope">
+          {{ scope.row.taxId }}
+        </span>
+        <span v-else-if="heard.columnName === 'Name'" slot-scope="scope">
+          {{ scope.row.name }}
+        </span>
+        <span v-else-if="heard.columnName === 'Name2'" slot-scope="scope">
+          {{ scope.row.lastName }}
+        </span>
+      </el-table-column>
+    </el-table>
+
+    <el-row :gutter="24" class="business-partners-footer">
+      <el-col :span="12">
+        <custom-pagination
+          :total="businessParnerData.recordCount"
+          :current-page="1"
+          :container-manager="containerManagerBPList"
+          :handle-change-page="setPage"
+          :selection="selection"
+        />
+      </el-col>
+
+      <el-col :span="12">
+        <samp style="float: right; padding-right: 10px;">
+          <el-button
+            type="danger"
+            class="custom-button-create-bp"
+            icon="el-icon-close"
+            @click="closeList"
+          />
+          <el-button
+            type="primary"
+            class="custom-button-create-bp"
+            icon="el-icon-check"
+            @click="changeBusinessPartner"
+          />
+          <!-- :disabled="isDisabled" -->
+        </samp>
+      </el-col>
+    </el-row>
+  </el-main>
+</template>
+
+<script>
+
+import FieldDefinition from '@theme/components/ADempiere/FieldDefinition/index.vue'
+import CustomPagination from '@theme/components/ADempiere/DefaultTable/CustomPagination.vue'
+
+// constants
+import { BUSINESS_PARTNERS_LIST_FORM } from '@/utils/ADempiere/dictionary/form/businessPartner/businessPartnerList'
+import fieldsList from './fieldsListSearch'
+
+// components and mixins
+import businessPartnerMixin from './mixinBusinessPartner'
+
+// utils and helper methods
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
+import {
+  // createFieldFromDefinition,
+  createFieldFromDictionary
+} from '@/utils/ADempiere/lookupFactory'
+import { containerManager as containerManagerForm } from '@/utils/ADempiere/dictionary/form'
+
+export default {
+  name: 'BusinessPartnersList',
+
+  components: {
+    CustomPagination,
+    FieldDefinition
+  },
+
+  mixins: [
+    businessPartnerMixin
+  ],
+
+  props: {
+    containerManager: {
+      type: Object,
+      default: () => ({
+        actionPerformed: () => {},
+        getFieldsLit: () => {},
+        setDefaultValues: () => {}
+      })
+    },
+    metadata: {
+      type: Object,
+      default: () => {
+        return {
+          containerUuid: BUSINESS_PARTNERS_LIST_FORM,
+          columnName: 'C_BPartner_ID'
+        }
+      }
+    },
+    showPopover: {
+      type: Boolean,
+      default: () => false
+    }
+  },
+
+  data() {
+    return {
+      activeAccordion: 'query-criteria',
+      fieldsList,
+      metadataList: [],
+      timeOutRecords: null,
+      isLoadingRecords: false,
+      timeOutFields: null,
+      isLoadingFields: false,
+      unsubscribe: () => {}
+    }
+  },
+
+  computed: {
+    uuidForm() {
+      if (!isEmptyValue(this.metadata.containerUuid)) {
+        return BUSINESS_PARTNERS_LIST_FORM + '_' + this.metadata.containerUuid
+      }
+      return BUSINESS_PARTNERS_LIST_FORM
+    },
+    shortsKey() {
+      return {
+        close: ['esc'],
+        refreshList: ['f5']
+      }
+    },
+    selection() {
+      if (isEmptyValue(this.currentRow)) {
+        return 0
+      }
+      return 1
+    },
+    containerManagerBPList() {
+      return {
+        ...this.containerManager,
+        ...containerManagerForm,
+        setPage: this.setPage
+      }
+    },
+    labelTable() {
+      return this.metadataList.map(field => {
+        return {
+          label: field.name,
+          columnName: field.columnName
+        }
+      })
+    },
+    businessParnerData() {
+      return this.$store.getters.getBusinessPartnerData({
+        containerUuid: this.uuidForm
+      })
+    },
+    businessPartnersList() {
+      return this.$store.getters.getBusinessPartnerRecordsList({
+        containerUuid: this.uuidForm
+      })
+    },
+    isReadyFromGetData() {
+      const { isLoaded } = this.businessParnerData
+      return !isLoaded && this.showPopover
+    },
+    currentRow: {
+      set(rowSelected) {
+        this.$store.commit('setBusinessPartnerSelectedRow', {
+          containerUuid: this.uuidForm,
+          currentRow: rowSelected
+        })
+      },
+      get() {
+        return this.$store.getters.getBusinessPartnerCurrentRow({
+          containerUuid: this.uuidForm
+        })
+      }
+    }
+  },
+
+  watch: {
+    isReadyFromGetData(isToLoad) {
+      if (isToLoad) {
+        this.searchBPartnerList()
+      }
+    },
+    showPopover(value) {
+      if (value && isEmptyValue(this.metadataList)) {
+        clearTimeout(this.timeOutFields)
+        this.timeOutFields = setTimeout(() => {
+          this.setFieldsList()
+        }, 500)
+      }
+    }
+  },
+
+  created() {
+    this.unsubscribe = this.subscribeChanges()
+
+    if (this.isReadyFromGetData) {
+      this.searchBPartnerList()
+    }
+  },
+
+  mounted() {
+    this.$nextTick(() => {
+      if (this.$refs.businessPartnerTable) {
+        this.$refs.businessPartnerTable.setCurrentRow(this.currentRow)
+      }
+    })
+
+    if (this.showPopover) {
+      clearTimeout(this.timeOutFields)
+      this.timeOutFields = setTimeout(() => {
+        this.setFieldsList()
+      }, 500)
+    }
+  },
+
+  beforeDestroy() {
+    this.unsubscribe()
+  },
+
+  methods: {
+    handleCurrentChange(row) {
+      this.currentRow = row
+    },
+    keyAction(event) {
+      console.log({ ...event })
+      switch (event.srcKey) {
+        case 'refreshList':
+          /**
+           * TODO: When refreshing you are making 2 list requests, you can be the
+           * observer that activates the second request
+          */
+          this.searchBPartnerList()
+          break
+
+        case 'close':
+          this.closeList()
+          break
+      }
+    },
+    changeBusinessPartner() {
+      if (!isEmptyValue(this.currentRow)) {
+        this.setBusinessPartner(this.currentRow)
+        this.closeList()
+      }
+    },
+    closeList() {
+      this.$store.commit('changePopoverListBusinessPartner', false)
+    },
+    setPage(pageNumber) {
+      this.searchBPartnerList(pageNumber)
+    },
+    subscribeChanges() {
+      return this.$store.subscribe((mutation, state) => {
+        if (mutation.type === 'updateValueOfField') {
+          if (mutation.payload.containerUuid === this.uuidForm) {
+            this.searchBPartnerList()
+          }
+        }
+      })
+    },
+    setFieldsList() {
+      const list = []
+      this.isLoadingFields = true
+      this.fieldsList.forEach(element => {
+        createFieldFromDictionary(element)
+          .then(response => {
+            const data = response
+            list.push({
+              ...data,
+              containerUuid: this.uuidForm
+            })
+          }).catch(error => {
+            console.warn(`LookupFactory: Get Field From Server (State) - Error ${error.code}: ${error.message}.`)
+          })
+      })
+      this.metadataList = list
+      this.isLoadingFields = false
+    },
+    searchBPartnerList(pageNumber = 0, isConvert = true) {
+      const values = this.$store.getters.getValuesView({
+        containerUuid: this.uuidForm,
+        format: 'object'
+      })
+
+      let parsedValues = values
+      if (isConvert && !isEmptyValue(values)) {
+        parsedValues = this.convertValuesToSend(values)
+      }
+      this.isLoadingRecords = true
+
+      clearTimeout(this.timeOutRecords)
+      this.timeOutRecords = setTimeout(() => {
+        // search on server
+        this.$store.dispatch('getBusinessPartners', {
+          ...parsedValues,
+          containerUuid: this.uuidForm,
+          pageNumber
+        })
+          .then(response => {
+            if (isEmptyValue(response)) {
+              this.$message({
+                type: 'warning',
+                showClose: true,
+                message: this.$t('businessPartner.notFound')
+              })
+            }
+          })
+          .finally(() => {
+            this.isLoadingRecords = false
+          })
+      }, 500)
+    },
+    /**
+     * ColumnName equals property to set into request's system-core
+     * TODO: Add keyServer and keyClient
+     * @param {object} values
+     * @returns {object}
+     */
+    convertValuesToSend(values) {
+      const valuesToSend = {}
+      Object.keys(values).forEach(key => {
+        const value = values[key]
+        if (isEmptyValue(value)) {
+          return
+        }
+        switch (key) {
+          // case 'TaxID':
+          //   valuesToSend['taxId'] = value
+          //   break
+          case 'Value':
+            valuesToSend['value'] = value
+            break
+          case 'Name':
+            valuesToSend['name'] = value
+            break
+        }
+      })
+
+      valuesToSend['posUuid'] = this.$store.getters.posAttributes.currentPointOfSales.uuid
+      return valuesToSend
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+.business-partners-list-container {
+  .business-partners-query-criteria {
+    // space between quey criteria and table
+    .el-collapse-item__content {
+      padding-bottom: 0px !important;
+    }
+  }
+}
+</style>

--- a/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo/buttonBusinessPartnersList.vue
+++ b/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo/buttonBusinessPartnersList.vue
@@ -1,0 +1,95 @@
+<!--
+ ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https:www.gnu.org/licenses/>.
+-->
+
+<template>
+  <el-popover
+    v-model="popoverListBusinessParnet"
+    placement="left-start"
+    width="900"
+    trigger="click"
+  >
+    <business-partners-list
+      :show-popover="popoverListBusinessParnet"
+      :metadata="parentMetadata"
+    />
+
+    <el-button
+      slot="reference"
+      class="button-search"
+      :disabled="isDisabled"
+    >
+      <i
+        class="el-icon-user-solid"
+      />
+    </el-button>
+  </el-popover>
+</template>
+
+<script>
+import store from '@/store'
+
+import BusinessPartnersList from './businessPartnersList.vue'
+
+export default {
+  name: 'ButtonBsuinessPartnersList',
+
+  components: {
+    BusinessPartnersList
+  },
+
+  props: {
+    parentMetadata: {
+      type: Object,
+      default: () => {
+        return {
+          parentUuid: undefined,
+          containerUuid: undefined,
+          columnName: 'C_BPartner_ID',
+          elementName: 'C_BPartner_ID'
+        }
+      }
+    },
+    isDisabled: {
+      type: Boolean,
+      default: false
+    }
+  },
+
+  computed: {
+    popoverListBusinessParnet: {
+      get() {
+        return store.getters.getBusinessPartnerPopoverList
+      },
+      set(value) {
+        store.commit('changePopoverListBusinessPartner', value)
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+.button-search {
+  padding-left: 9px !important;
+  padding-right: 0px !important;
+
+  i {
+    font-size: 20px !important;
+  }
+}
+</style>

--- a/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo/fieldsListSearch.js
+++ b/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo/fieldsListSearch.js
@@ -1,0 +1,67 @@
+/**
+ * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// List of fields to send in search
+export default [
+  {
+    elementColumnName: 'Value',
+    columnName: 'Value',
+    tableName: 'C_BPartner',
+    isFromDictionary: true,
+    overwriteDefinition: {
+      sequence: 1,
+      componentPath: 'FieldText',
+      size: 6,
+      isCustomField: true
+    }
+  },
+  {
+    elementColumnName: 'TaxID',
+    columnName: 'TaxID',
+    fieldUuid: '8cef473e-fb40-11e8-a479-7a0060f0aa01',
+    uuid: '8cef473e-fb40-11e8-a479-7a0060f0aa01',
+    isFromDictionary: true,
+    overwriteDefinition: {
+      sequence: 2,
+      size: 6,
+      isCustomField: true
+    }
+  },
+  {
+    elementColumnName: 'Name',
+    columnName: 'Name',
+    tableName: 'C_BPartner',
+    isFromDictionary: true,
+    overwriteDefinition: {
+      sequence: 3,
+      size: 6,
+      isCustomField: true
+    }
+  },
+  {
+    elementColumnName: 'Name2',
+    columnName: 'Name2',
+    tableName: 'C_BPartner',
+    isFromDictionary: true,
+    overwriteDefinition: {
+      sequence: 4,
+      size: 6,
+      isCustomField: true
+    }
+  }
+]

--- a/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo/index.vue
+++ b/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo/index.vue
@@ -1,0 +1,321 @@
+<!--
+ ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https:www.gnu.org/licenses/>.
+-->
+
+<template>
+  <div>
+    <el-autocomplete
+      ref="displayBPartner"
+      v-model="displayedValue"
+      v-bind="commonsProperties"
+      value-key="name"
+      style="width: 100%;"
+      popper-class="custom-field-bpartner-info"
+      :trigger-on-focus="false"
+      :fetch-suggestions="localSearch"
+      :select-when-unmatched="false"
+      @select="handleSelect"
+      @clear="setBusinessPartner(blankBPartner)"
+      @focus="setNewDisplayedValue"
+      @blur="setOldDisplayedValue"
+    >
+      <!--
+      @keyup.enter.native="getBPartnerWithEnter"
+       -->
+      <template slot-scope="recordRow">
+        <div class="header">
+          <b> {{ recordRow.item.name }} {{ recordRow.item.lastName }}</b>
+        </div>
+        <span class="info">
+          {{ recordRow.item.value }} {{ recordRow.item.taxId }} {{ recordRow.item.description }}
+        </span>
+      </template>
+
+      <button-business-partners-list
+        slot="append"
+        :parent-metadata="metadata"
+        :is-disabled="isDisabled"
+      />
+    </el-autocomplete>
+  </div>
+</template>
+
+<script>
+import store from '@/store'
+
+// components and mixins
+import fieldMixin from '@theme/components/ADempiere/FieldDefinition/mixin/mixinField.js'
+import businessPartnerMixin from './mixinBusinessPartner'
+import ButtonBusinessPartnersList from './buttonBusinessPartnersList.vue'
+
+// utils and helper methods
+import { isEmptyValue, isSameValues } from '@/utils/ADempiere/valueUtils'
+import { trimPercentage } from '@/utils/ADempiere/valueFormat'
+
+export default {
+  name: 'BusinessPartnerInfo',
+
+  components: {
+    ButtonBusinessPartnersList
+  },
+
+  mixins: [
+    fieldMixin,
+    businessPartnerMixin
+  ],
+
+  props: {
+    parentMetadata: {
+      type: Object,
+      default: () => {
+        return {
+          containerUuid: ''
+        }
+      }
+    },
+    showsPopovers: {
+      type: Object,
+      default: () => {
+        return {
+          isShowCreate: false,
+          isShowList: false
+        }
+      }
+    }
+  },
+
+  data() {
+    return {
+      timeOut: null,
+      searchText: '',
+      controlDisplayed: this.displayedValue
+    }
+  },
+
+  computed: {
+    recordsBusinessPartners() {
+      return this.$store.getters.getBusinessPartnerRecordsList({
+        containerUuid: this.metadata.containerUuid
+      })
+    },
+    value: {
+      get() {
+        const { columnName, containerUuid, inTable } = this.metadata
+        // table records values
+        if (inTable) {
+          // implement container manager row
+          if (this.containerManager && this.containerManager.getCell) {
+            return this.containerManager.getCell({
+              containerUuid,
+              rowIndex: this.metadata.rowIndex,
+              columnName
+            })
+          }
+        }
+
+        return this.$store.getters.getValueOfFieldOnContainer({
+          parentUuid: this.metadata.parentUuid,
+          containerUuid,
+          columnName
+        })
+      },
+      set(value) {
+        const { columnName, containerUuid, inTable } = this.metadata
+
+        // table records values
+        if (inTable) {
+          // implement container manager row
+          if (this.containerManager && this.containerManager.setCell) {
+            return this.containerManager.setCell({
+              containerUuid,
+              rowIndex: this.metadata.rowIndex,
+              columnName,
+              value
+            })
+          }
+        }
+
+        // const option = this.findOption(value)
+        // // always update uuid
+        // this.uuidValue = option.uuid
+
+        this.$store.commit('updateValueOfField', {
+          parentUuid: this.metadata.parentUuid,
+          containerUuid,
+          columnName,
+          value
+        })
+        // update element column name
+        if (columnName !== this.metadata.elementName) {
+          this.$store.commit('updateValueOfField', {
+            parentUuid: this.metadata.parentUuid,
+            containerUuid,
+            columnName: this.metadata.elementName,
+            value
+          })
+        }
+      }
+    },
+    displayedValue: {
+      get() {
+        const display = store.getters.getValueOfField({
+          containerUuid: this.metadata.containerUuid,
+          columnName: this.metadata.displayColumnName
+        })
+        return display
+      },
+      set(value) {
+        store.commit('updateValueOfField', {
+          containerUuid: this.metadata.containerUuid,
+          columnName: this.metadata.displayColumnName,
+          value
+        })
+      }
+    }
+  },
+
+  methods: {
+    setNewDisplayedValue() {
+      const displayValue = this.displayedValue
+      this.displayedValue = '' // clear to enter search
+      if (!isSameValues(this.controlDisplayed, displayValue)) {
+        this.controlDisplayed = displayValue
+      }
+    },
+    setOldDisplayedValue() {
+      if (!isSameValues(this.controlDisplayed, this.displayedValue)) {
+        this.displayedValue = this.controlDisplayed
+      }
+    },
+    localSearch(stringToMatch, callBack) {
+      if (isEmptyValue(stringToMatch)) {
+        // not show list
+        callBack([])
+        return
+      }
+
+      const recordsList = this.recordsBusinessPartners
+      let results = recordsList
+      if (stringToMatch) {
+        const parsedValue = trimPercentage(stringToMatch.toLowerCase().trim())
+
+        results = recordsList.filter(rowBPartner => {
+          for (const columnBPartner in rowBPartner) {
+            const valueToCompare = String(rowBPartner[columnBPartner]).toLowerCase()
+
+            if (valueToCompare.includes(parsedValue)) {
+              return true
+            }
+          }
+          return false
+        })
+
+        // Remote search
+        if (this.isEmptyValue(results) && String(stringToMatch.length > 3)) {
+          clearTimeout(this.timeOut)
+
+          this.timeOut = setTimeout(() => {
+            this.remoteSearch(stringToMatch)
+              .then(remoteResponse => {
+                callBack(remoteResponse)
+              })
+          }, 2000)
+          return
+        }
+      }
+
+      // call callback function to return suggestions
+      callBack(results)
+    },
+
+    remoteSearch(searchValue) {
+      return new Promise(resolve => {
+        const message = {
+          message: this.$t('notifications.searchWithOutRecords'),
+          type: 'info',
+          showClose: true
+        }
+
+        store.dispatch('getBusinessPartners', {
+          containerUuid: this.metadata.containerUuid,
+          pageNumber: 1,
+          searchValue
+        })
+          .then(responseRecords => {
+            if (isEmptyValue(responseRecords)) {
+              this.$message(message)
+            }
+
+            resolve(responseRecords)
+          })
+          .catch(error => {
+            console.warn(error.message)
+
+            this.$message(message)
+            resolve([])
+          })
+      })
+    },
+
+    handleSelect(businessPartnerSelected) {
+      if (this.isEmptyValue(businessPartnerSelected)) {
+        businessPartnerSelected = this.blankBPartner
+      }
+      this.setBusinessPartner(businessPartnerSelected)
+
+      // prevent losing display value with focus
+      this.controlDisplayed = this.generateDisplayedValue(businessPartnerSelected)
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+.custom-field-bpartner-info {
+  // button icon suffix
+  .button-search {
+    padding-left: 10px !important;
+    padding-right: 10px !important;
+
+    >i {
+      font-size: 20px;
+    }
+  }
+}
+</style>
+<style lang="scss" scope>
+.custom-field-bpartner-info {
+  // items of lust
+  li {
+    line-height: normal;
+    // padding: 15px;
+    padding-bottom: 5px;
+    padding-top: 5px;
+
+    .header {
+      text-overflow: ellipsis;
+      overflow: hidden;
+    }
+
+    .info {
+      color: #7e7e7e;
+      float: left;
+      font-size: 12px;
+    }
+  }
+}
+</style>

--- a/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo/mixinBusinessPartner.js
+++ b/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo/mixinBusinessPartner.js
@@ -1,0 +1,120 @@
+/**
+ * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// constants
+import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
+
+// utils and helper methods
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
+
+export default {
+  name: 'MixinBusinessPartner',
+
+  props: {
+    metadata: {
+      type: Object,
+      default: () => {
+        return {
+          parentUuid: undefined,
+          containerUuid: undefined,
+          columnName: 'C_BPartner_ID',
+          elementName: 'C_BPartner_ID'
+        }
+      }
+    }
+  },
+
+  computed: {
+    blankBPartner() {
+      return {
+        id: undefined,
+        uuid: undefined,
+        name: undefined,
+        lastName: undefined,
+        value: undefined
+      }
+    }
+  },
+  methods: {
+    generateDisplayedValue({ value, name, lastName }) {
+      let displayedValue = value + ' - ' + name
+      if (!isEmptyValue(lastName)) {
+        displayedValue += ' ' + lastName
+      }
+
+      return displayedValue
+    },
+    setBusinessPartner({ id, uuid, value, name, lastName, description }) {
+      const { parentUuid, containerUuid, columnName, elementName } = this.metadata
+      const displayedValue = this.generateDisplayedValue({
+        value,
+        name,
+        lastName
+      })
+
+      // set ID value
+      this.$store.commit('updateValueOfField', {
+        parentUuid,
+        containerUuid,
+        columnName,
+        value: id
+      })
+      // set display column (name) value
+      this.$store.commit('updateValueOfField', {
+        parentUuid,
+        containerUuid,
+        // DisplayColumn_'ColumnName'
+        columnName: DISPLAY_COLUMN_PREFIX + columnName,
+        value: displayedValue
+      })
+      // set UUID value
+      this.$store.commit('updateValueOfField', {
+        parentUuid,
+        containerUuid,
+        columnName: columnName + '_UUID',
+        value: uuid
+      })
+
+      // set on element name, used by columns views aliases
+      if (!isEmptyValue(elementName) && columnName !== elementName) {
+        // set ID value
+        this.$store.commit('updateValueOfField', {
+          parentUuid,
+          containerUuid,
+          columnName: elementName,
+          value: id
+        })
+        // set display column (name) value
+        this.$store.commit('updateValueOfField', {
+          parentUuid,
+          containerUuid,
+          // DisplayColumn_'ColumnName'
+          columnName: DISPLAY_COLUMN_PREFIX + elementName,
+          value: displayedValue
+        })
+        // set UUID value
+        this.$store.commit('updateValueOfField', {
+          parentUuid,
+          containerUuid,
+          columnName: elementName + '_UUID',
+          value: uuid
+        })
+      }
+    }
+  }
+}

--- a/components/ADempiere/FieldDefinition/FieldSearch/index.vue
+++ b/components/ADempiere/FieldDefinition/FieldSearch/index.vue
@@ -1,0 +1,95 @@
+<template>
+  <component
+    :is="componentRender"
+    :parent-uuid="parentUuid"
+    :container-uuid="containerUuid"
+    :container-manager="containerManager"
+    :metadata="metadata"
+  />
+</template>
+
+<script>
+// utils and helper methods
+import { isEmptyValue } from '@/utils/ADempiere'
+
+/**
+ * This component emulates the behavior of the search field, contemplating:
+ * - Search Field
+ * - InfoBPartner
+ * - InfoProduct
+ * - InfoInvoice
+ * - InfoAsset
+ * - InfoOrder
+ * - InfoInOut
+ * - InfoPayment
+ * - InfoCashLine
+ * - InfoAssignment
+ * - InfoGeneral
+ */
+export default {
+  name: 'FieldSearch',
+
+  props: {
+    parentUuid: {
+      type: String,
+      default: undefined
+    },
+    containerUuid: {
+      type: String,
+      required: true
+    },
+    containerManager: {
+      type: Object,
+      required: true
+    },
+    // receives the property that is an object with all the attributes
+    metadata: {
+      type: Object,
+      default: () => ({})
+    }
+  },
+
+  computed: {
+    // load the component that is indicated in the attributes of received property
+    componentRender() {
+      // let fieldRender = () => import('@theme/components/ADempiere/FieldDefinition/FieldSearch/GeneralInfo')
+      let fieldRender = () => import('@theme/components/ADempiere/FieldDefinition/FieldSelect')
+      if (isEmptyValue(this.metadata.reference)) {
+        return fieldRender
+      }
+
+      switch (this.metadata.reference.tableName) {
+        case 'C_BPartner':
+          fieldRender = () => import('@theme/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo')
+          break
+        // case 'M_Product':
+        //   fieldRender = () => import('@theme/components/ADempiere/FieldDefinition/FieldSearch/ProductInfo')
+        //   break
+        // case 'C_Invoice':
+        //   fieldRender = () => import('@theme/components/ADempiere/FieldDefinition/FieldSearch/InvoiceInfo')
+        //   break
+        // case 'A_Asset':
+        //   fieldRender = () => import('@theme/components/ADempiere/FieldDefinition/FieldSearch/AssetInfo')
+        //   break
+        // case 'C_Order':
+        //   fieldRender = () => import('@theme/components/ADempiere/FieldDefinition/FieldSearch/OrderInfo')
+        //   break
+        // case 'M_InOut':
+        //   fieldRender = () => import('@theme/components/ADempiere/FieldDefinition/FieldSearch/InOutPartnerInfo')
+        //   break
+        // case 'C_Payment':
+        //   fieldRender = () => import('@theme/components/ADempiere/FieldDefinition/FieldSearch/PaymentInfo')
+        //   break
+        // case 'C_CashLine':
+        //   fieldRender = () => import('@theme/components/ADempiere/FieldDefinition/FieldSearch/CashLineInfo')
+        //   break
+        // case 'S_ResourceAssigment':
+        //   fieldRender = () => import('@theme/components/ADempiere/FieldDefinition/FieldSearch/ResourceAssigmentInfo')
+        //   break
+      }
+
+      return fieldRender
+    }
+  }
+}
+</script>

--- a/components/ADempiere/FieldDefinition/FieldSelect.vue
+++ b/components/ADempiere/FieldDefinition/FieldSelect.vue
@@ -33,6 +33,13 @@
     @visible-change="getDataLookupList"
     @clear="clearLookup"
   >
+    <svg-icon
+      v-if="isSearchField"
+      slot="prefix"
+      icon-class="search"
+      style="margin-left: 5px; font-size: 16px;"
+    />
+
     <el-option
       v-for="(option, key) in optionsList"
       :key="key"
@@ -58,9 +65,6 @@ import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
  *
  * TODO: String values add single quotation marks 'value'
  * TODO: No blanck option enabled if is mandatory field
- * TODO: ALL: Although in the future these will have different components, and
- * are currently not supported is also displayed as a substitute for fields:
- * - Search Field
  */
 export default {
   name: 'FieldSelect',
@@ -71,6 +75,12 @@ export default {
   ],
 
   computed: {
+    /**
+     * Lookup search type unsupported
+     */
+    isSearchField() {
+      return this.metadata.componentPath === 'FieldSearch'
+    },
     cssClassStyle() {
       let styleClass = ' custom-field-select '
       if (this.isSelectMultiple) {

--- a/components/ADempiere/FieldDefinition/index.vue
+++ b/components/ADempiere/FieldDefinition/index.vue
@@ -144,7 +144,9 @@ export default {
       return 'field-standard'
     },
     currentColumnSize() {
-      return store.getters.getSizeColumn({ containerUuid: this.containerUuid })
+      return store.getters.getSizeColumn({
+        containerUuid: this.containerUuid
+      })
     },
     sizeField() {
       if (this.field.containerUuid === LOCATION_ADDRESS_FORM) {
@@ -157,6 +159,17 @@ export default {
           xl: 24
         }
       }
+      if (!this.field.isCustomField && DEFAULT_COLUMNS_PER_ROW >= 0 && !this.isMobile) {
+        const size = parseInt(LAYOUT_MAX_COLUMNS_PER_ROW / this.currentColumnSize, 10)
+        return {
+          xs: size,
+          sm: size,
+          md: size,
+          lg: size,
+          xl: size
+        }
+      }
+
       if (isEmptyValue(this.field.size)) {
         const size = 24
         return {
@@ -166,16 +179,6 @@ export default {
           lg: size,
           xl: size,
           ...DEFAULT_SIZE
-        }
-      }
-      if (DEFAULT_COLUMNS_PER_ROW >= 0 && !this.isMobile) {
-        const size = parseInt(LAYOUT_MAX_COLUMNS_PER_ROW / this.currentColumnSize, 10)
-        return {
-          xs: size,
-          sm: size,
-          md: size,
-          lg: size,
-          xl: size
         }
       }
       return {

--- a/components/ADempiere/Form/VPOS/BusinessPartner/businessPartnersList.vue
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/businessPartnersList.vue
@@ -252,7 +252,6 @@ export default {
     isMandatoryField,
     isReadOnlyField,
     changeFieldShowedFromUser,
-    createFieldFromDictionary,
     actionList(event) {
       this.$store.dispatch('changePopoverListBusinessPartner', false)
     },
@@ -311,7 +310,7 @@ export default {
       const list = []
       // Product Code
       this.fieldsList.forEach(element => {
-        this.createFieldFromDictionary(element)
+        createFieldFromDictionary(element)
           .then(response => {
             const data = response
             list.push({

--- a/components/ADempiere/Form/VPOS/BusinessPartner/index.vue
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/index.vue
@@ -340,30 +340,26 @@ export default {
     },
     displayedValue: {
       get() {
+        if (this.isEmptyValue(this.oldValueCustomer) && !this.isEmptyValue(this.newCustomer) && !this.editBusinessPartner &&
+          this.isEmptyValue(this.$store.getters.posAttributes.currentPointOfSales.currentOrder.uuid)) {
+          return this.newCustomer.value + this.newCustomer.name
+        }
+        if (!this.isEmptyValue(this.$refs.displayBPartner) && !this.$refs.displayBPartner.$refs.input.focused) {
+          if (!this.isEmptyValue(this.oldValueCustomer)) {
+            return this.oldValueCustomerData + this.displayAddress(this.selectAddress.first_name)
+          }
+          if (this.isEmptyValue(this.$store.getters.posAttributes.currentPointOfSales.currentOrder.uuid)) {
+            return this.templateCustomerData + this.displayAddress(this.selectAddress.first_name)
+          } else {
+            return this.orderCustomerData + this.displayAddress(this.selectAddress.first_name)
+          }
+        }
+
         const display = this.$store.getters.getValueOfField({
           containerUuid: this.parentMetadata.containerUuid,
           columnName: 'DisplayColumn_C_BPartner_ID' // this.parentMetadata.displayColumnName
         })
-        if (this.isEmptyValue(this.oldValueCustomer) && !this.isEmptyValue(this.newCustomer) && !this.editBusinessPartner && this.isEmptyValue(this.$store.getters.posAttributes.currentPointOfSales.currentOrder.uuid)) {
-          return this.newCustomer.value + this.newCustomer.name
-        }
-        if (this.isEmptyValue(this.$store.getters.posAttributes.currentPointOfSales.currentOrder.uuid)) {
-          if (!this.isEmptyValue(this.oldValueCustomer) && !this.isEmptyValue(this.$refs.displayBPartner) && !this.$refs.displayBPartner.$refs.input.focused) {
-            return this.oldValueCustomerData + this.displayAddress(this.selectAddress.first_name)
-          }
-          if (!this.isEmptyValue(this.$refs.displayBPartner) && !this.$refs.displayBPartner.$refs.input.focused) {
-            return this.templateCustomerData + this.displayAddress(this.selectAddress.first_name)
-          }
-          return display
-        } else {
-          if (!this.isEmptyValue(this.oldValueCustomer) && !this.isEmptyValue(this.$refs.displayBPartner) && !this.$refs.displayBPartner.$refs.input.focused) {
-            return this.oldValueCustomerData + this.displayAddress(this.selectAddress.first_name)
-          }
-          if (!this.isEmptyValue(this.$refs.displayBPartner) && !this.$refs.displayBPartner.$refs.input.focused) {
-            return this.orderCustomerData + this.displayAddress(this.selectAddress.first_name)
-          }
-          return display
-        }
+        return display
       },
       set(value) {
         this.$store.commit('updateValueOfField', {

--- a/components/ADempiere/Form/VPOS/containerManagerPos.js
+++ b/components/ADempiere/Form/VPOS/containerManagerPos.js
@@ -45,6 +45,10 @@ export function isDisplayedField({ displayType, isActive, isDisplayed, isDisplay
   return isActive && isDisplayed && isDisplayedFromLogic
 }
 
+export function isDisplayedDefault({ isMandatory }) {
+  return true
+}
+
 export function isReadOnlyField({ isQueryCriteria, isReadOnlyFromLogic }) {
   return isQueryCriteria && isReadOnlyFromLogic
 }


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Aging` report.
2. Showed `Business Partner` field.
3. Search value with input text and select any record.
4. Click on icon and search values.
5. Select a row and click on the blue ok button to set or if you prefer double click on the row to set the record.


The search by the autocomplete text entry searches only the columns Value, Name, Name2 and Description.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/180309879-5cf8731d-f373-448f-a906-c97d4b4c0767.mp4



#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/273
Depends on https://github.com/solop-develop/backend/pull/37
