### PR TITLE
fix: Business Partner Info displayed value.

### DIFF
--- a/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo/index.vue
+++ b/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo/index.vue
@@ -188,6 +188,14 @@ export default {
     }
   },
 
+  created() {
+    this.unsubscribe = this.subscribeChanges()
+  },
+
+  beforeDestroy() {
+    this.unsubscribe()
+  },
+
   methods: {
     setNewDisplayedValue() {
       const displayValue = this.displayedValue
@@ -200,6 +208,30 @@ export default {
       if (!isSameValues(this.controlDisplayed, this.displayedValue)) {
         this.displayedValue = this.controlDisplayed
       }
+    },
+    subscribeChanges() {
+      return this.$store.subscribe((mutation, state) => {
+        if (mutation.type === 'updateValueOfField') {
+          if (mutation.payload.containerUuid === this.metadata.containerUuid) {
+            // add displayed value to persistence
+            if (mutation.payload.columnName === this.metadata.columnName) {
+              this.preHandleChange(mutation.payload.value)
+
+              this.$store.dispatch('notifyFieldChange', {
+                containerUuid: this.metadata.containerUuid,
+                containerManager: this.containerManager,
+                field: this.metadata,
+                columnName: this.metadata.displayColumnName
+              })
+            }
+
+            if (mutation.payload.columnName === this.metadata.displayColumnName) {
+              // set current displayed value to clean on focus
+              this.controlDisplayed = mutation.payload.value
+            }
+          }
+        }
+      })
     },
     localSearch(stringToMatch, callBack) {
       if (isEmptyValue(stringToMatch)) {

--- a/components/ADempiere/FieldDefinition/mixin/mixinField.js
+++ b/components/ADempiere/FieldDefinition/mixin/mixinField.js
@@ -235,8 +235,7 @@ export default {
      * validate values before send values to store or server
      * @param {mixed} value
      */
-    preHandleChange(value, a, b, c) {
-      // console.log({ value, a, b, c }, 3123123, this.value)
+    preHandleChange(value) {
       this.handleFieldChange({ value })
     },
     focusGained(value) {

--- a/components/ADempiere/RecordAccess/recordAccess.js
+++ b/components/ADempiere/RecordAccess/recordAccess.js
@@ -14,9 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { setRecordAccess } from '@/api/ADempiere/actions/record-access.js'
-import { showMessage } from '@/utils/ADempiere/notification.js'
 import language from '@/lang'
+
+// api request methods
+import { setRecordAccess } from '@/api/ADempiere/actions/record-access.js'
+
+// utils and helpers methods
+import { isLookup } from '@/utils/ADempiere/references'
+import { showMessage } from '@/utils/ADempiere/notification.js'
+
 export default {
   name: 'MixinRecordAccess',
   props: {
@@ -89,7 +95,7 @@ export default {
     },
     getIdentifiersList() {
       return this.identifiersList
-        .filter(item => item.componentPath !== 'FieldSelect')
+        .filter(item => !isLookup(item.displayType))
     },
     listRecordAccess() {
       return this.$store.getters.getRecordAccess

--- a/components/ADempiere/TabManager/convenienceButtons.vue
+++ b/components/ADempiere/TabManager/convenienceButtons.vue
@@ -172,6 +172,9 @@ export default defineComponent({
         const record = store.getters.getTabCurrentRow({
           containerUuid
         })
+        if (isEmptyValue(record)) {
+          return []
+        }
         return [record]
       }
       return selectionsRecords.value


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `User` window.
2. Show `Business Partner` field.

A. Without save changes.
1. Select a record without `Business Partner`.
2. Set any `Business Partner`.

B. Without clear displayed value.
1. Select a record with `Business Partner`.
2. Click on `New`.

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/180478646-5ec2e1ae-4ade-474e-8b01-f04c3324eb27.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/180478650-9c22606a-db49-4c79-abb4-cc047f7a6eac.mp4

#### Expected behavior
A. When fill `Business Partner` field, change value and `Save` are displayed.
B. When clic on `New` button, clear old set value.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes: https://github.com/solop-develop/frontend-core/issues/247
Depends on https://github.com/solop-develop/backend/pull/38
