### PR TITLE
fix: Duplicated option field change log.

### DIFF
--- a/components/ADempiere/FieldDefinition/FieldOptions/index.vue
+++ b/components/ADempiere/FieldDefinition/FieldOptions/index.vue
@@ -344,7 +344,10 @@ export default defineComponent({
         return optionsButton.concat(menuOptions)
       }
 
-      const optionsList = optionsListStandad
+      // destruct to avoid deleting the reference to the original variable and to avoid mutating
+      const optionsList = [
+        ...optionsListStandad
+      ]
 
       /**
        * Show change history only in windows


### PR DESCRIPTION

#### Stepts to reproduce:
1. Open any window.
2. Click on label field to showed field options.

#### Expected behavior:
The `Change History` field option is expected to appear only once.


#### Screenshots

Before this changes:

https://user-images.githubusercontent.com/20288327/184167212-846cc667-f52c-4f0b-a945-9df4a1c0a4e0.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/184167204-d9ff26dd-b1be-4d1e-9b97-f9a3feba37cd.mp4


#### Additional context:

fixes https://github.com/solop-develop/frontend-core/issues/264