### PR TITLE
fix: Currency rate with same currency.

### DIFF
--- a/components/ADempiere/Form/VPOS/Collection/index.vue
+++ b/components/ADempiere/Form/VPOS/Collection/index.vue
@@ -221,8 +221,9 @@ import typeCollection from '@theme/components/ADempiere/Form/VPOS/Collection/typ
 import overdrawnInvoice from './overdrawnInvoice'
 
 // utils and helper methods
+import { isEmptyValue, isSameValues } from '@/utils/ADempiere/valueUtils'
 import { formatPrice, formatDateToSend } from '@/utils/ADempiere/valueFormat.js'
-import { clientDateTime } from '@/utils/ADempiere/formatValue/dateFormat.js'
+import { clientDateTime } from '@/utils/ADempiere/formatValue/dateFormat'
 import {
   getLookupList,
   isDisplayedField,
@@ -233,6 +234,7 @@ import {
   isReadOnlyField,
   changeFieldShowedFromUser
 } from '@theme/components/ADempiere/Form/VPOS/containerManagerPos.js'
+
 // api request methods
 import { processOrder } from '@/api/ADempiere/form/point-of-sales.js'
 
@@ -709,11 +711,16 @@ export default {
 
   watch: {
     dateConvertions(value) {
-      if (!this.isEmptyValue(this.currentPointOfSales.conversionTypeUuid) && !this.isEmptyValue(this.currentPointOfSales.priceList.currency.uuid) && !this.isEmptyValue(this.selectCurrentFieldCurrency.uuid) && !this.isEmptyValue(value) && this.formatDateToSend(this.currentPointOfSales.currentOrder.dateOrdered) !== value) {
+      const currencyFromUuid = this.currentPointOfSales.priceList.currency.uuid
+      const currencyToUuid = this.selectCurrentFieldCurrency.uuid
+      if (!isEmptyValue(this.currentPointOfSales.conversionTypeUuid) &&
+        !isEmptyValue(currencyFromUuid) && !isEmptyValue(currencyToUuid) &&
+        !isSameValues(currencyFromUuid, currencyToUuid) &&
+        !isEmptyValue(value) && this.formatDateToSend(this.currentPointOfSales.currentOrder.dateOrdered) !== value) {
         this.$store.dispatch('searchConversion', {
           conversionTypeUuid: this.currentPointOfSales.conversionTypeUuid,
-          currencyFromUuid: this.currentPointOfSales.priceList.currency.uuid,
-          currencyToUuid: this.selectCurrentFieldCurrency.uuid,
+          currencyFromUuid,
+          currencyToUuid,
           conversionDate: clientDateTime(value, 'd')
         })
       }

--- a/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
+++ b/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
@@ -280,10 +280,10 @@ export default {
     convertedAmount() {
       if (!this.isEmptyValue(this.currentPointOfSales.displayCurrency) && this.totalAmountConverted === 1) {
         this.$store.dispatch('searchConversion', {
+          // conversionDate: this.formatDateToSend(this.currentPointOfSales.currentOrder.dateOrdered),
           conversionTypeUuid: this.currentPointOfSales.conversionTypeUuid,
           currencyFromUuid: this.currentPointOfSales.currentPriceList.currency.uuid,
-          currencyToUuid: this.currentPointOfSales.displayCurrency.uuid,
-          conversionDate: this.formatDateToSend(this.currentPointOfSales.currentOrder.dateOrdered)
+          currencyToUuid: this.currentPointOfSales.displayCurrency.uuid
         })
       }
     },


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

http://0.0.0.0:8085/api/adempiere/common/conversion-rate?pos_uuid=c2828298-607f-49e9-b0c1-54ab020890d6&conversion_type_uuid=f11f895c-2b0c-4b65-9a1e-782f3f0df850&currency_from_uuid=a567befe-fb40-11e8-a479-7a0060f0aa01&currency_to_uuid=a567befe-fb40-11e8-a479-7a0060f0aa01&conversion_date=2022-08-30&token=50c71b91-8b5c-4a5e-b188-1e989430c470&language=es

![Screenshot_20220830_135820](https://user-images.githubusercontent.com/20288327/187509540-c74d69d5-e93d-4605-b786-ad068970bdf3.png)

```
No existe tasa de cambio registrada al dia 2022-08-30, Bs.S => Bs.S
```

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.


