### PR TITLE
fix: Load records on tab childs.

### DIFF
--- a/components/ADempiere/TabManager/tabChild.vue
+++ b/components/ADempiere/TabManager/tabChild.vue
@@ -113,10 +113,8 @@ import { defineComponent, computed, watch, ref, onUnmounted } from '@vue/composi
 
 import router from '@/router'
 import store from '@/store'
-import language from '@/lang'
 
 // components and mixins
-// import AuxiliaryPanel from '@theme/components/ADempiere/AuxiliaryPanel/index.vue'
 import DefaultTable from '@theme/components/ADempiere/DataTable/index.vue'
 import TabLabel from '@theme/components/ADempiere/TabManager/TabLabel.vue'
 import TabPanel from './TabPanel.vue'
@@ -133,7 +131,6 @@ export default defineComponent({
   name: 'TabManager',
 
   components: {
-    // AuxiliaryPanel,
     DefaultTable,
     TabPanel,
     TabLabel,
@@ -219,20 +216,6 @@ export default defineComponent({
       return key > 0 && (isCreateNew.value || isEmptyValue(recordUuidTabParent.value))
     }
 
-    const listAction = computed(() => {
-      return {
-        parentUuid: props.parentUuid,
-        containerUuid: props.tabsList[currentTab.value].uuid,
-        defaultActionName: language.t('actionMenu.createNewRecord'),
-        tableName: props.tabsList[currentTab.value].tableName,
-        getActionList: () => {
-          return store.getters.getStoredActionsMenu({
-            containerUuid: props.tabsList[currentTab.value].uuid
-          })
-        }
-      }
-    })
-
     function changeShowedRecords() {
       store.dispatch('changeTabAttribute', {
         attributeName: 'isShowedTableRecords',
@@ -264,33 +247,6 @@ export default defineComponent({
     const handleClick = (tabHTML) => {
       const { tabuuid, tabindex } = tabHTML.$attrs
 
-      const inf = store.getters.getContainerInfo
-      const infoTab = props.tabsList.find(row => row.uuid === tabuuid)
-      if (!isEmptyValue(inf)) {
-        if (!isEmptyValue(infoTab)) {
-          if (!isEmptyValue(inf.currentTab)) {
-            store.dispatch('changeTabAttribute', {
-              parentUuid: inf.currentTab.parentUuid,
-              containerUuid: inf.currentTab.containerUuid,
-              attributeName: 'isSelected',
-              attributeValue: false
-            })
-          }
-          const list = store.getters.getTabRecordsList({ containerUuid: infoTab.containerUuid })
-          const currentRecord = list.find(row => row.UUID === store.getters.getUuidOfContainer(infoTab.containerUuid))
-          store.dispatch('panelInfo', {
-            currentTab: infoTab,
-            currentRecord
-          })
-          store.dispatch('changeTabAttribute', {
-            parentUuid: infoTab.parentUuid,
-            containerUuid: infoTab.containerUuid,
-            attributeName: 'isSelected',
-            attributeValue: true
-          })
-        }
-      }
-
       setTabNumber(tabindex)
 
       // set metadata tab
@@ -298,9 +254,48 @@ export default defineComponent({
         tabUuid.value = tabuuid
         setCurrentTab()
       }
+
+      const containerInfo = store.getters.getContainerInfo
+      if (!isEmptyValue(containerInfo)) {
+        const currentTabDefinition = props.tabsList.find(row => row.uuid === tabuuid)
+        if (!isEmptyValue(currentTabDefinition)) {
+          if (!isEmptyValue(currentTabDefinition.currentTab)) {
+            store.dispatch('changeTabAttribute', {
+              parentUuid: containerInfo.currentTab.parentUuid,
+              containerUuid: containerInfo.currentTab.containerUuid,
+              attributeName: 'isSelected',
+              attributeValue: false
+            })
+          }
+          const currentTabData = store.getters.getTabData({
+            containerUuid: tabuuid
+          })
+
+          const recordsListTab = currentTabData.recordsList
+          let currentRecord = {}
+          if (isEmptyValue(recordsListTab)) {
+            if (!currentTabData.isLoaded && !currentTabData.isLoading) {
+              // load records
+              getData()
+            }
+          } else {
+            currentRecord = recordsListTab.find(row => row.UUID === store.getters.getUuidOfContainer(currentTabDefinition.containerUuid))
+            store.dispatch('panelInfo', {
+              currentTab: currentTabDefinition,
+              currentRecord
+            })
+          }
+          store.dispatch('changeTabAttribute', {
+            parentUuid: currentTabDefinition.parentUuid,
+            containerUuid: currentTabDefinition.containerUuid,
+            attributeName: 'isSelected',
+            attributeValue: true
+          })
+        }
+      }
     }
 
-    const setTabNumber = (tabNumber = '0') => {
+    function setTabNumber(tabNumber = '0') {
       if (isEmptyValue(tabNumber)) {
         tabNumber = '0'
       }
@@ -340,7 +335,7 @@ export default defineComponent({
       })
     })
 
-    const getData = () => {
+    function getData() {
       const containerUuid = tabUuid.value
       const filters = []
       if (!isEmptyValue(root.$route.query) &&
@@ -500,10 +495,10 @@ export default defineComponent({
       isShowedTabs,
       showedTabsList,
       isMobile,
-      listAction,
       currentTabMetadata,
       recordUuidTabParent,
       isShowedTableRecords,
+      tabData,
       tabStyle,
       // methods
       handleClick,


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with `GardenAdmin` role.
2. Open `Business Partner` window.
3. Click on different child tabs.

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/191795329-c039d3ad-603f-424c-a53d-e19c8d088d1d.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/191795322-a128dcea-5f8a-4032-ad9a-f0e8c7e4f8f8.mp4

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.20.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Depends on https://github.com/solop-develop/frontend-core/pull/405
