### PR TITLE
fixed: Accouting combination overwrite changes.

### DIFF
--- a/components/ADempiere/FieldDefinition/FieldAccountingCombination/index.vue
+++ b/components/ADempiere/FieldDefinition/FieldAccountingCombination/index.vue
@@ -18,13 +18,13 @@
 
 <template>
   <el-autocomplete
-    ref="displayBPartner"
+    :ref=" metadata.columnName"
     v-model="displayedValue"
     v-bind="commonsProperties"
     value-key="name"
     clearable
     style="width: 100%;"
-    popper-class="custom-field-bpartner-info"
+    popper-class="custom-field-accouting-combination"
     :trigger-on-focus="false"
     :fetch-suggestions="localSearch"
     :select-when-unmatched="false"
@@ -70,7 +70,7 @@ import mixinAccountingCombination from './mixinAccountingCombination.js'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
 
 export default {
-  name: 'FieldAccount',
+  name: 'FieldAccountingCombination',
 
   components: {
     ButtonToList
@@ -104,11 +104,10 @@ export default {
     },
     displayedValue: {
       get() {
-        const display = this.$store.getters.getValueOfField({
+        return this.$store.getters.getValueOfField({
           containerUuid: this.metadata.containerUuid,
           columnName: this.metadata.displayColumnName
         })
-        return display
       },
       set(value) {
         this.$store.commit('updateValueOfField', {
@@ -119,9 +118,16 @@ export default {
       }
     }
   },
+
+  beforeMount() {
+    if (this.metadata.displayed) {
+      this.setDisplayedValue()
+    }
+  },
+
   methods: {
     keyPressField() {
-      if (!this.isEmptyValue(this.$refs['displayBPartner' + this.metadata.columnName])) {
+      if (!this.isEmptyValue(this.$refs[this.metadata.columnName])) {
         this.remoteSearch(this.displayedValue, true)
       }
     },
@@ -161,7 +167,7 @@ export default {
 </script>
 
 <style lang="scss">
-.custom-field-bpartner-info {
+.custom-field-accouting-combination {
   // button icon suffix
   .button-search {
     padding-left: 10px !important;
@@ -174,7 +180,7 @@ export default {
 }
 </style>
 <style lang="scss" scope>
-.custom-field-bpartner-info {
+.custom-field-accouting-combination {
   // items of lust
   li {
     line-height: normal;

--- a/components/ADempiere/FieldDefinition/FieldAccountingCombination/mixinAccountingCombination.js
+++ b/components/ADempiere/FieldDefinition/FieldAccountingCombination/mixinAccountingCombination.js
@@ -17,13 +17,16 @@
  */
 
 // constants
-import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
+import {
+  DISPLAY_COLUMN_PREFIX, UNIVERSALLY_UNIQUE_IDENTIFIER_COLUMN_SUFFIX
+} from '@/utils/ADempiere/dictionaryUtils'
+import { COLUMN_NAME } from '@/utils/ADempiere/dictionary/form/accoutingCombination'
 
 // utils and helper methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
 
 export default {
-  name: 'mixinFieldAccount',
+  name: 'mixinAccountingCombination',
 
   props: {
     metadata: {
@@ -32,8 +35,8 @@ export default {
         return {
           parentUuid: undefined,
           containerUuid: undefined,
-          columnName: 'C_BPartner_ID',
-          elementName: 'C_BPartner_ID'
+          columnName: COLUMN_NAME,
+          elementName: COLUMN_NAME
         }
       }
     }
@@ -51,7 +54,7 @@ export default {
       }
     },
     recordsList() {
-      return this.$store.getters.getBusinessPartnerRecordsList({
+      return this.$store.getters.getAccountCombinationsRecordsList({
         containerUuid: this.uuidForm
       })
     }
@@ -60,37 +63,16 @@ export default {
     clearValues() {
       this.setValues(this.blankValues)
     },
-    generateDisplayedValue({ value, name, lastName }) {
-      let displayedValue
-
-      if (!isEmptyValue(value)) {
-        displayedValue = value
-      }
-      if (!isEmptyValue(name)) {
-        if (!isEmptyValue(displayedValue)) {
-          displayedValue += ' - ' + name
-        } else {
-          displayedValue = name
-        }
-      }
-      if (!isEmptyValue(lastName)) {
-        displayedValue += ' ' + lastName
-      }
-
-      return displayedValue
-    },
     setValues(rowData) {
       const { parentUuid, containerUuid, columnName, elementName } = this.metadata
-      const { [columnName]: id, UUID: uuid, IdentifierTable } = rowData
-
-      const displayedValue = this.generateDisplayedValue(rowData)
+      const { C_ValidCombination_ID: id, UUID: uuid, Combination: displayedValue } = rowData
 
       // set ID value
       this.$store.commit('updateValueOfField', {
         parentUuid,
         containerUuid,
         columnName,
-        value: this.isEmptyValue(id) ? rowData[IdentifierTable + '_ID'] : id
+        value: id
       })
       // set display column (name) value
       this.$store.commit('updateValueOfField', {
@@ -104,7 +86,7 @@ export default {
       this.$store.commit('updateValueOfField', {
         parentUuid,
         containerUuid,
-        columnName: columnName + '_UUID',
+        columnName: columnName + UNIVERSALLY_UNIQUE_IDENTIFIER_COLUMN_SUFFIX,
         value: uuid
       })
 
@@ -129,7 +111,7 @@ export default {
         this.$store.commit('updateValueOfField', {
           parentUuid,
           containerUuid,
-          columnName: elementName + '_UUID',
+          columnName: elementName + UNIVERSALLY_UNIQUE_IDENTIFIER_COLUMN_SUFFIX,
           value: uuid
         })
       }


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with `GardenAdmin` role.
2. Open `Business Partner Group` window.
3. List any accouting combination field.
4. Set any value

#### Screenshot or Gif
After this changes:

https://user-images.githubusercontent.com/20288327/191846034-ec09f835-02cb-45f9-a41b-b7c9112e0ff1.mp4

Before this changes:

https://user-images.githubusercontent.com/20288327/191875402-f163c84d-5bce-4b02-b2eb-862a29a10538.mp4


#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.20.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Depends on https://github.com/solop-develop/frontend-core/pull/406