### PR TITLE
fix: Displayed value on search field forms.

### DIFF
--- a/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo/index.vue
+++ b/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo/index.vue
@@ -104,6 +104,12 @@ export default {
     }
   },
 
+  beforeMount() {
+    if (this.metadata.displayed) {
+      this.setDisplayedValue()
+    }
+  },
+
   methods: {
     keyPressField() {
       if (!this.isEmptyValue(this.$refs['displayBPartner' + this.metadata.columnName])) {
@@ -130,6 +136,7 @@ export default {
           parentUuid = this.metadata.containerUuid
         }
 
+        this.isLoading = true
         this.containerManager.getSearchInfoList({
           parentUuid,
           containerUuid: this.metadata.containerUuid,
@@ -151,6 +158,9 @@ export default {
 
             this.whitOutResultsMessage()
             resolve([])
+          })
+          .finally(() => {
+            this.isLoading = false
           })
       })
     }

--- a/components/ADempiere/FieldDefinition/FieldSearch/GeneralInfoSearch/index.vue
+++ b/components/ADempiere/FieldDefinition/FieldSearch/GeneralInfoSearch/index.vue
@@ -113,9 +113,16 @@ export default {
     }
   },
 
+  beforeMount() {
+    if (this.metadata.displayed) {
+      this.setDisplayedValue()
+    }
+  },
+
   methods: {
     remoteSearch(searchValue) {
       return new Promise(resolve => {
+        this.isLoading = true
         this.containerManager.generalInfoSearch({
           containerUuid: this.metadata.containerUuid,
           parentUuid: this.metadata.containerUuid,
@@ -137,6 +144,9 @@ export default {
 
             this.whitOutResultsMessage()
             resolve([])
+          })
+          .finally(() => {
+            this.isLoading = false
           })
       })
     }

--- a/components/ADempiere/FieldDefinition/FieldSelect.vue
+++ b/components/ADempiere/FieldDefinition/FieldSelect.vue
@@ -391,7 +391,7 @@ export default {
       // Establish
       this.setContainerInformation()
       // get stored list values
-      const list = this.getStoredLookupList
+      const list = this.getStoredLookupAll
       // refresh local list component
       this.optionsList = list
       if (isShowList) {

--- a/components/ADempiere/FieldDefinition/mixin/mixinFieldSelect.js
+++ b/components/ADempiere/FieldDefinition/mixin/mixinFieldSelect.js
@@ -87,7 +87,6 @@ export default {
       // sets the value to blank when the lookupList or lookupItem have no
       // values, or if only lookupItem does have a value
       if (isEmptyValue(allOptions) || (!isEmptyValue(allOptions) &&
-        // (!this.blankValues.includes(allOptions[0].id)))) {
         (!this.blankValues.includes(allOptions[0].value)))) {
         allOptions.unshift(this.blankOption)
       }

--- a/components/ADempiere/FieldDefinition/mixin/mixinFieldSelect.js
+++ b/components/ADempiere/FieldDefinition/mixin/mixinFieldSelect.js
@@ -86,7 +86,7 @@ export default {
 
       // sets the value to blank when the lookupList or lookupItem have no
       // values, or if only lookupItem does have a value
-      if (isEmptyValue(allOptions) || (allOptions.length &&
+      if (isEmptyValue(allOptions) || (!isEmptyValue(allOptions) &&
         // (!this.blankValues.includes(allOptions[0].id)))) {
         (!this.blankValues.includes(allOptions[0].value)))) {
         allOptions.unshift(this.blankOption)


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Business Parner Group` window.
2. Open any `Accouting Combination` field.
3. Set `Product` or `Business Partner` value.
4. Save and set accouting combination.
5. Open same list of `Accouting Combination` field.

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/191946775-4d900ac7-b9a8-4db9-93cb-1b5b3ed90b67.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/191946780-85a03a46-3a61-43d0-b1d4-507113001086.mp4


#### Expected behavior
When opening a search that in the search criteria has search fields it was not setting the display value, in case of not having the display value of the context it uses the default value request to obtain the display value and the uuid of the record from the value of the key column.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.20.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Depends on https://github.com/solop-develop/frontend-core/pull/407
