### PR TITLE
feat: POS Remove Box uom hard code.

### DIFF
--- a/components/ADempiere/Form/VPOS/Order/index.vue
+++ b/components/ADempiere/Form/VPOS/Order/index.vue
@@ -667,9 +667,6 @@ export default {
     isMobile() {
       return this.$store.state.app.device === 'mobile'
     },
-    isShowedPOSKeyLaout() {
-      return this.$store.getters.getShowPOSKeyLayout
-    },
     currentPriceTableEdit: {
       get(value) {
         return this.currentValuePriceLine(this.currentLineOrder)

--- a/components/ADempiere/Form/VPOS/Order/line/index.vue
+++ b/components/ADempiere/Form/VPOS/Order/line/index.vue
@@ -320,18 +320,10 @@ export default {
           return uomItem.uom.uuid === this.uomValue
         })
         if (!isEmptyValue(this.uomSelected)) {
-          // TODO: Remove it with fix on ADempiere (Box UOM)
-          if (uomSelected.code === 'BX') {
-            return 0
-          }
           return uomSelected.uom.starndard_precision
         }
       }
       if (this.currentLine.uom && this.currentLine.uom.uom) {
-        // TODO: Remove it with fix on ADempiere (Box UOM)
-        if (this.currentLine.uom.uom.code === 'BX') {
-          return 0
-        }
         return this.currentLine.uom.uom.starndard_precision
       }
       return undefined

--- a/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
+++ b/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
@@ -373,9 +373,8 @@ export default {
             value: row.quantityOrdered
           })
         }
-        // TODO: Remove it with fix on ADempiere (Box UOM)
         let precision = row.uom.uom.starndard_precision
-        if (row.uom.uom.code === 'BX') {
+        if (isEmptyValue(precision)) {
           precision = 0
         }
         return formatQuantity({
@@ -428,9 +427,8 @@ export default {
             value: row.quantityOrdered
           })
         }
-        // TODO: Remove it with fix on ADempiere (Box UOM)
         let precision = row.uom.uom.starndard_precision
-        if (row.uom.uom.code === 'BX') {
+        if (isEmptyValue(precision)) {
           precision = 0
         }
         return formatQuantity({


### PR DESCRIPTION
With uom is Box, the standard precision is 0. Remove hard code and manage from ADempiere.

