### PR TITLE
fix: POS Message pin validate successfully unnecessary.

### DIFF
--- a/components/ADempiere/Form/VPOS/Options/AssignSeller/index.vue
+++ b/components/ADempiere/Form/VPOS/Options/AssignSeller/index.vue
@@ -199,11 +199,8 @@ export default {
       this.assignSeller()
     },
     unassignSeller() {
-      this.$message({
-        message: this.$t('pointOfSales.pin.validateSuccessfully'),
-        showClose: true
-      })
       this.$store.commit('setShowUnassignSeller', false)
+
       deallocate({
         posUuid: this.$store.getters.posAttributes.currentPointOfSales.uuid,
         salesRepresentativeUuid: this.salesRepresentative.uuid
@@ -264,11 +261,8 @@ export default {
       this.listAvailableSellers()
     },
     assignSeller() {
-      this.$message({
-        message: this.$t('pointOfSales.pin.validateSuccessfully'),
-        showClose: true
-      })
       this.$store.commit('setShowAssignSeller', false)
+
       allocateSeller({
         posUuid: this.$store.getters.posAttributes.currentPointOfSales.uuid,
         salesRepresentativeUuid: this.salesRepresentative.uuid

--- a/components/ADempiere/Form/VPOS/Options/CashOpening/index.vue
+++ b/components/ADempiere/Form/VPOS/Options/CashOpening/index.vue
@@ -1070,10 +1070,7 @@ export default {
         format: 'object'
       })
       this.$store.commit(this.currentPanel.commit, false)
-      this.$message({
-        message: this.$t('pointOfSales.pin.validateSuccessfully'),
-        showClose: true
-      })
+
       cashOpening({
         posUuid: this.currentPointOfSales.uuid,
         collectingAgentUuid: this.collectAgentUuid,

--- a/components/ADempiere/Form/VPOS/Options/CashSummaryMovements/index.vue
+++ b/components/ADempiere/Form/VPOS/Options/CashSummaryMovements/index.vue
@@ -131,10 +131,7 @@ export default {
     },
     cashClose() {
       this.$store.commit('setShowCashSummaryMovements', false)
-      this.$message({
-        message: this.$t('pointOfSales.pin.validateSuccessfully'),
-        showClose: true
-      })
+
       cashClosing({
         posUuid: this.$store.getters.posAttributes.currentPointOfSales.uuid,
         id: this.listCashSummary.id,

--- a/components/ADempiere/Form/VPOS/Options/Cashwithdrawal/index.vue
+++ b/components/ADempiere/Form/VPOS/Options/Cashwithdrawal/index.vue
@@ -1064,10 +1064,7 @@ export default {
         format: 'object'
       })
       this.$store.commit(this.currentPanel.commit, false)
-      this.$message({
-        message: this.$t('pointOfSales.pin.validateSuccessfully'),
-        showClose: true
-      })
+
       cashWithdrawal({
         posUuid: this.currentPointOfSales.uuid,
         collectingAgentUuid: this.collectAgentUuid,

--- a/components/ADempiere/Form/VPOS/Options/index.vue
+++ b/components/ADempiere/Form/VPOS/Options/index.vue
@@ -346,7 +346,7 @@
                     type="primary"
                     class="custom-button-create-bp"
                     icon="el-icon-check"
-                    @click="addCount(discountAmount)"
+                    @click="applyDiscount(discountAmount)"
                   />
                 </div>
                 <el-button
@@ -391,7 +391,7 @@
                     type="primary"
                     class="custom-button-create-bp"
                     icon="el-icon-check"
-                    @click="SalesDiscount(discountRateOff)"
+                    @click="salesDiscount(discountRateOff)"
                   />
                 </div>
                 <el-button
@@ -1053,7 +1053,7 @@ export default {
       if (this.showCount) {
         switch (event.srcKey) {
           case 'enter':
-            if (this.discountAmount > 1) this.addCount(this.discountAmount)
+            if (this.discountAmount > 1) this.applyDiscount(this.discountAmount)
             break
           case 'close':
             this.showCount = false
@@ -1070,7 +1070,7 @@ export default {
       if (this.showSalesDiscount) {
         switch (event.srcKey) {
           case 'enter':
-            if (this.discountAmount > 0) this.SalesDiscount(this.discountRateOff)
+            if (this.discountAmount > 0) this.salesDiscount(this.discountRateOff)
             break
           case 'close':
             this.showSalesDiscount = false
@@ -1475,11 +1475,7 @@ export default {
           })
         })
     },
-    addCount(discountAmount) {
-      this.$message({
-        message: this.$t('pointOfSales.pin.validateSuccessfully'),
-        showClose: true
-      })
+    applyDiscount(discountAmount) {
       this.$store.dispatch('updateOrder', {
         orderUuid: this.currentOrder.uuid,
         posUuid: this.currentPointOfSales.uuid,
@@ -1500,11 +1496,7 @@ export default {
         })
       this.showCount = false
     },
-    SalesDiscount(discountRateOff) {
-      this.$message({
-        message: this.$t('pointOfSales.pin.validateSuccessfully'),
-        showClose: true
-      })
+    salesDiscount(discountRateOff) {
       this.$store.dispatch('updateOrder', {
         orderUuid: this.currentOrder.uuid,
         posUuid: this.currentPointOfSales.uuid,


### PR DESCRIPTION
An unnecessary `Pin successfully validated` message appears when performing the following actions:

- Unassign Seller.
- Assign Seller.
- Cash Opening.
- Cash Close.
- Cash Withdrawal.
- Apply Discount.
- Sales Discount.


