### PR TITLE
fixed: SB Field Search query criteria.

### DIFF
--- a/components/ADempiere/FieldDefinition/FieldAccountingCombination/mixinAccountingCombination.js
+++ b/components/ADempiere/FieldDefinition/FieldAccountingCombination/mixinAccountingCombination.js
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 // constants
@@ -21,9 +21,6 @@ import {
   DISPLAY_COLUMN_PREFIX, UNIVERSALLY_UNIQUE_IDENTIFIER_COLUMN_SUFFIX
 } from '@/utils/ADempiere/dictionaryUtils'
 import { COLUMN_NAME } from '@/utils/ADempiere/dictionary/form/accoutingCombination'
-
-// utils and helper methods
-import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
 
 export default {
   name: 'mixinAccountingCombination',
@@ -45,12 +42,9 @@ export default {
   computed: {
     blankValues() {
       return {
-        id: undefined,
-        uuid: undefined,
-        value: undefined,
-        name: undefined,
-        lastName: undefined,
-        description: undefined
+        C_ValidCombination_ID: undefined,
+        UUID: undefined,
+        Combination: undefined
       }
     },
     recordsList() {
@@ -85,13 +79,32 @@ export default {
       ]
     }
   },
+
   methods: {
     clearValues() {
       this.setValues(this.blankValues)
     },
+    /**
+     * @overwrite
+     * Get custom displayed value
+     * @returns {string}
+     */
+    generateDisplayedValue(recordRow) {
+      // generate with standard columns
+      const { Combination } = recordRow
+
+      return Combination
+    },
+    /**
+     * @overwrite
+     * Set custom row on fields values
+     * @returns {string}
+     */
     setValues(rowData) {
       const { parentUuid, containerUuid, columnName, elementName } = this.metadata
-      const { C_ValidCombination_ID: id, UUID: uuid, Combination: displayedValue } = rowData
+      const { C_ValidCombination_ID: id, UUID: uuid } = rowData
+
+      const displayedValue = this.generateDisplayedValue(rowData)
 
       // set ID value
       this.$store.commit('updateValueOfField', {
@@ -117,7 +130,7 @@ export default {
       })
 
       // set on element name, used by columns views aliases
-      if (!isEmptyValue(elementName) && columnName !== elementName) {
+      if (!this.metadata.isSameColumnElement) {
         // set ID value
         this.$store.commit('updateValueOfField', {
           parentUuid,
@@ -141,6 +154,7 @@ export default {
           value: uuid
         })
       }
+
       this.$store.dispatch('notifyFieldChange', {
         containerUuid: this.metadata.containerUuid,
         containerManager: this.containerManager,

--- a/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo/businessPartnersList.vue
+++ b/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo/businessPartnersList.vue
@@ -13,7 +13,7 @@
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program.  If not, see <https:www.gnu.org/licenses/>.
+ along with this program. If not, see <https:www.gnu.org/licenses/>.
 -->
 
 <template>
@@ -135,6 +135,7 @@ import fieldsList from './fieldsListSearch'
 
 // components and mixins
 import businessPartnerMixin from './mixinBusinessPartner'
+import fieldSearchMixin from '../mixinFieldSearch'
 import CellDisplayInfo from '@theme/components/ADempiere/DataTable/Components/CellDisplayInfo.vue'
 import CustomPagination from '@theme/components/ADempiere/DataTable/Components/CustomPagination.vue'
 import IndexColumn from '@theme/components/ADempiere/DataTable/Components/IndexColumn.vue'
@@ -159,6 +160,7 @@ export default {
   },
 
   mixins: [
+    fieldSearchMixin,
     businessPartnerMixin
   ],
 
@@ -331,8 +333,8 @@ export default {
     },
     changeBusinessPartner() {
       if (!isEmptyValue(this.currentRow)) {
-        this.closeList()
         this.setValues(this.currentRow)
+        this.closeList()
       }
     },
     closeList() {

--- a/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo/mixinBusinessPartner.js
+++ b/components/ADempiere/FieldDefinition/FieldSearch/BusinessPartnerInfo/mixinBusinessPartner.js
@@ -13,11 +13,8 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
-
-// constants
-import { DISPLAY_COLUMN_PREFIX } from '@/utils/ADempiere/dictionaryUtils'
 
 // utils and helper methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
@@ -42,12 +39,18 @@ export default {
   computed: {
     blankValues() {
       return {
+        [this.metadata.columnName]: undefined,
+        [this.metadata.elementName]: undefined,
         id: undefined,
         uuid: undefined,
         value: undefined,
+        Value: undefined,
+        taxId: undefined,
+        TaxID: undefined,
         name: undefined,
+        Name: undefined,
         lastName: undefined,
-        description: undefined
+        LastName: undefined
       }
     },
     recordsList() {
@@ -57,9 +60,11 @@ export default {
     }
   },
   methods: {
-    clearValues() {
-      this.setValues(this.blankValues)
-    },
+    /**
+     * @overwrite
+     * Get custom displayed value
+     * @returns {string}
+     */
     generateDisplayedValue({ Value, Name, LastName }) {
       let displayedValue
 
@@ -78,70 +83,6 @@ export default {
       }
 
       return displayedValue
-    },
-    setValues(rowData) {
-      const { parentUuid, containerUuid, columnName, elementName } = this.metadata
-      const { UUID, Value, Name, LastName } = rowData
-      const displayedValue = this.generateDisplayedValue({
-        Value,
-        Name,
-        LastName
-      })
-
-      // set ID value
-      this.$store.commit('updateValueOfField', {
-        parentUuid,
-        containerUuid,
-        columnName,
-        value: rowData[columnName]
-      })
-      // set display column (name) value
-      this.$store.commit('updateValueOfField', {
-        parentUuid,
-        containerUuid,
-        // DisplayColumn_'ColumnName'
-        columnName: DISPLAY_COLUMN_PREFIX + columnName,
-        value: displayedValue
-      })
-      // set UUID value
-      this.$store.commit('updateValueOfField', {
-        parentUuid,
-        containerUuid,
-        columnName: columnName + '_UUID',
-        value: UUID
-      })
-
-      // set on element name, used by columns views aliases
-      if (!isEmptyValue(elementName) && columnName !== elementName) {
-        // set ID value
-        this.$store.commit('updateValueOfField', {
-          parentUuid,
-          containerUuid,
-          columnName: elementName,
-          value: rowData[columnName]
-        })
-        // set display column (name) value
-        this.$store.commit('updateValueOfField', {
-          parentUuid,
-          containerUuid,
-          // DisplayColumn_'ColumnName'
-          columnName: DISPLAY_COLUMN_PREFIX + elementName,
-          value: displayedValue
-        })
-        // set UUID value
-        this.$store.commit('updateValueOfField', {
-          parentUuid,
-          containerUuid,
-          columnName: elementName + '_UUID',
-          value: UUID
-        })
-      }
-      this.$store.dispatch('notifyFieldChange', {
-        containerUuid: this.metadata.containerUuid,
-        containerManager: this.containerManager,
-        field: this.metadata,
-        columnName: this.metadata.columnName
-      })
     }
   }
 }

--- a/components/ADempiere/FieldDefinition/mixin/mixinField.js
+++ b/components/ADempiere/FieldDefinition/mixin/mixinField.js
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
@@ -388,7 +388,7 @@ export default {
           columnName: this.metadata.columnName,
           value
         })
-        if (this.metadata.columnName !== this.metadata.elementName) {
+        if (!this.metadata.isSameColumnElement) {
           this.$store.dispatch('notifyActionPerformed', {
             containerUuid: this.metadata.containerUuid,
             columnName: this.metadata.elementName,

--- a/components/ADempiere/FieldDefinition/useFieldDefinition.js
+++ b/components/ADempiere/FieldDefinition/useFieldDefinition.js
@@ -1,7 +1,7 @@
 /**
  * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
- * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
- * Contributor(s): Edwin Betancourt EdinBetanc0urt@outlook.com www.erpya.com
+ * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -13,7 +13,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 import { computed, onMounted } from '@vue/composition-api'
@@ -298,7 +298,7 @@ export default function useFieldDefinition({ fieldMetadata, containerManager }) 
         columnName: fieldMetadata.columnName,
         value
       })
-      if (fieldMetadata.columnName !== fieldMetadata.elementName) {
+      if (!fieldMetadata.isSameColumnElement) {
         store.dispatch('notifyActionPerformed', {
           containerUuid: fieldMetadata.containerUuid,
           columnName: fieldMetadata.elementName,


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with `Garden Admin` role.
2. Open `User Browser` smart browser.
3. Show `Business Partner` query criteria.
4. Set any value in `Business Partner` field.

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/193020913-103e4805-8bd3-49db-a9f6-7dd3d8a0e08f.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/193020915-b3103fb5-a4e3-4b73-9c1a-7cbf8c6c69e9.mp4

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.20.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.




#### Additional context
Depends on https://github.com/solop-develop/frontend-core/pull/419