### PR TITLE
fix: Cache list lookups.

### DIFF
--- a/components/ADempiere/FieldDefinition/FieldSelect.vue
+++ b/components/ADempiere/FieldDefinition/FieldSelect.vue
@@ -1,7 +1,7 @@
 <!--
  ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
- Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
- Contributor(s): Yamel Senih ysenih@erpya.com www.erpya.com
+ Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
@@ -13,7 +13,7 @@
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with this program.  If not, see <https:www.gnu.org/licenses/>.
+ along with this program. If not, see <https:www.gnu.org/licenses/>.
 -->
 
 <template>
@@ -33,13 +33,6 @@
     @visible-change="getDataLookupList"
     @clear="clearLookup"
   >
-    <svg-icon
-      v-if="isSearchField"
-      slot="prefix"
-      icon-class="search"
-      style="margin-left: 5px; font-size: 16px;"
-    />
-
     <el-option
       v-for="(option, key) in optionsList"
       :key="key"
@@ -75,12 +68,6 @@ export default {
   ],
 
   computed: {
-    /**
-     * Lookup search type unsupported
-     */
-    isSearchField() {
-      return this.metadata.componentPath === 'FieldSearch'
-    },
     cssClassStyle() {
       let styleClass = ' custom-field-select '
       if (this.isSelectMultiple) {
@@ -388,26 +375,30 @@ export default {
      * @param {boolean} isShowList triggers when the pull-down menu appears or disappears
      */
     getDataLookupList(isShowList) {
-      // Establish
+      // establish
       this.setContainerInformation()
-      // get stored list values
-      const list = this.getStoredLookupAll
-      // refresh local list component
-      this.optionsList = list
+      // get stored list and refresh local component
+      this.optionsList = this.getStoredLookupAll
+
       if (isShowList) {
-        if (this.isEmptyValue(list) || this.isWithSearchValue ||
-          (list.length === 1 && this.blankValues.includes(list[0].value))) {
+        const listLookups = this.getStoredLookupList
+        if (isEmptyValue(listLookups) || this.isWithSearchValue) {
           this.loadListFromServer()
+        } else if (listLookups.length === 1) {
+          const firstOption = listLookups.at(0)
+          if (firstOption && this.blankValues.includes(firstOption.value)) {
+            this.loadListFromServer()
+          }
         }
       }
     },
     remoteSearch(searchQuery = '') {
-      clearTimeout(this.timeOut)
       const results = this.localSearch(searchQuery)
-      if ((this.isEmptyValue(results) && !this.isEmptyValue(searchQuery)) || this.isEmptyValue(searchQuery)) {
+      if (this.isEmptyValue(searchQuery) && (this.isEmptyValue(results) && !this.isEmptyValue(searchQuery))) {
+        clearTimeout(this.timeOut)
         this.timeOut = setTimeout(() => {
           this.loadListFromServer(searchQuery)
-        }, 600)
+        }, 500)
         return
       }
       // use this, if remote is enabled, local search not working
@@ -454,7 +445,8 @@ export default {
       this.$store.dispatch('deleteLookup', {
         parentUuid: this.metadata.parentUuid,
         containerUuid: this.metadata.containerUuid,
-        contextColumnNames: this.metadata.contextColumnNames,
+        contextColumnNames: this.metadata.reference.contextColumnNames,
+        contextColumnNamesByDefaultValue: this.metadata.contextColumnNames,
         uuid: this.metadata.uuid,
         //
         tableName: this.metadata.reference.tableName,


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with `Garden Admin` role.
2. Open `Business Partner Group` window.
3. Show `Organization` field.
4. Click on `New` button.
5. List `Organization` field list.

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/193479169-cb001a3c-521b-4a0a-ae9a-5fe5d71fde75.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/193479178-939542e7-6ef0-4ce0-9a61-79d89d2ac626.mp4


#### Expected behavior

If you load a default value in a lookup type field and then list that field, not all records are listed but only the one loaded through the default value.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.20.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Depends on https://github.com/solop-develop/frontend-core/pull/431