### PR TITLE
fix: Set default accouting schema from context session.

### DIFF
--- a/components/ADempiere/PanelInfo/index.vue
+++ b/components/ADempiere/PanelInfo/index.vue
@@ -65,7 +65,6 @@
         v-model="nameTab"
         type="border-card"
         style="height: 100% !important;"
-        class="qlq"
         @tab-click="handleClick"
       >
         <el-tab-pane name="getRecordLogs">
@@ -152,8 +151,7 @@
           </span>
           <accounting
             :container-manager="containerManager"
-            :container-uuid="currentTab.containerUuid + '_  AccountingInformation'"
-            :container-uuid-tab="currentTab.containerUuid"
+            :container-uuid="currentTab.containerUuid"
             :table-name="currentTab.tableName"
             :record-id="currentRecordInfo[currentTab.tableName + '_ID']"
             :record-uuid="$store.getters.getUuidOfContainer(currentTab.containerUuid)"


### PR DESCRIPTION
When opening the accounting information the default value in the Accounting Schema field is not set, now when opening it the value of the session context in `$C_AcctSchema_ID` is set.

https://user-images.githubusercontent.com/20288327/193497321-feeaf5e3-7995-49fe-8a1d-5b7e8ce654b0.mp4

