### PR TITLE
feat: Location Address open map.

### DIFF
--- a/components/ADempiere/FieldDefinition/FieldLocationAddress/fieldsList.js
+++ b/components/ADempiere/FieldDefinition/FieldLocationAddress/fieldsList.js
@@ -163,7 +163,7 @@ export default [
     overwriteDefinition: {
       isCustomField: true,
       size: 24,
-      precision: 0,
+      precision: 6,
       index: 110
     }
   },
@@ -173,7 +173,7 @@ export default [
     overwriteDefinition: {
       isCustomField: true,
       size: 24,
-      precision: 0,
+      precision: 6,
       index: 120
     }
   },
@@ -183,7 +183,7 @@ export default [
     overwriteDefinition: {
       isCustomField: true,
       size: 24,
-      precision: 0,
+      precision: 6,
       index: 130
     }
   }

--- a/components/ADempiere/FieldDefinition/FieldLocationAddress/index.vue
+++ b/components/ADempiere/FieldDefinition/FieldLocationAddress/index.vue
@@ -35,7 +35,7 @@
     class="popover-location"
     placement="left-end"
     width="350"
-    trigger="manual"
+    trigger="click"
   >
     <location-address-form
       v-if="isShowedLocationForm"
@@ -52,7 +52,6 @@
       type="text"
       style="width: 100%;"
       :disabled="isDisabled"
-      @click="isShowedLocationForm = true"
     >
       <el-input
         v-model="displayedValueNotEdit"

--- a/components/ADempiere/FieldDefinition/FieldLocationAddress/mixinLocationAddress.js
+++ b/components/ADempiere/FieldDefinition/FieldLocationAddress/mixinLocationAddress.js
@@ -119,7 +119,8 @@ export default {
     },
     /**
      * Displayed sequence location
-     * TODO: Evaluate capture sequence by Germany "@A1@ @A2@ @A3@ @A4@ D-@P@ @R@ @C@ @CO@" with D- suffix in postal code
+     * TODO: Evaluate capture sequence or displayed sequence to generate value
+     * TODO: Test capture sequence Germany "@A1@ @A2@ @A3@ @A4@ D-@P@ @R@ @C@ @CO@" with D- suffix in postal code
      * @param {object} entityValues
      * @returns {string}
      */
@@ -203,7 +204,7 @@ export default {
 
           if (this.isEmptyValue(currrentValue)) {
             currrentValue = this.$store.getters.getValueOfField({
-              containerUuid: LOCATION_ADDRESS_FORM,
+              containerUuid: this.uuidForm,
               columnName: displayColumnName
             })
           }


### PR DESCRIPTION
Added support to open the google map based on the location address values, considering that in vue if it has coordinates it will take as priority those values for the search, in case of not having coordinates, it will perform a search with the display value of the address:

Example with coordinate values https://www.google.com/maps?q=10.046955,-69.325574

Example with display value https://www.google.com/maps?q=,+OR,+Furniture+Transit,+United+States


#### Zk Version:

https://user-images.githubusercontent.com/20288327/196710708-56bb342f-22c7-4122-86c0-f9634a5ea650.mp4



#### Vue Version:

https://user-images.githubusercontent.com/20288327/196710657-2f124994-e8c9-47b1-84d4-110e21959741.mp4


#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/510
