### PR TITLE
fix: POS Disable print when is loading

### DIFF
--- a/components/ADempiere/Form/VPOS/Options/index.vue
+++ b/components/ADempiere/Form/VPOS/Options/index.vue
@@ -122,7 +122,6 @@
           </el-col>
 
           <!-- generateImmediateInvoice -->
-
           <el-col :span="size" style="padding-left: 12px;padding-right: 12px;padding-bottom: 10px;">
             <el-card shadow="hover" style="height: 100px">
               <p
@@ -137,7 +136,6 @@
           </el-col>
 
           <!-- completePreparedOrder -->
-
           <el-col :span="size" style="padding-left: 12px;padding-right: 12px;padding-bottom: 10px;">
             <el-card shadow="hover" style="height: 100px">
               <p
@@ -152,7 +150,6 @@
           </el-col>
 
           <!-- cancelSaleTransaction -->
-
           <el-col v-if="allowsReturnOrder" :span="size" style="padding-left: 12px;padding-right: 12px;padding-bottom: 10px;">
             <el-card shadow="hover" style="height: 100px">
               <el-popover
@@ -222,7 +219,8 @@
             <el-card shadow="hover" style="height: 100px">
               <el-button
                 type="text"
-                :disabled="isEmptyValue(currentOrder.uuid) || !isAllowsPrintDocument"
+                :disabled="isEmptyValue(currentOrder.uuid) || !isAllowsPrintDocument || isLoadingPrintTicket"
+                :loading="isLoadingPrintTicket"
                 :class="isEmptyValue(currentOrder.uuid) ? 'is-disabled-option-card' : 'is-enable-option-card'"
                 style="overflow: hidden; text-overflow: ellipsis; white-space: normal;"
                 @click="printTicket()"
@@ -239,10 +237,11 @@
             <el-card shadow="hover" style="height: 100px">
               <el-button
                 type="text"
-                :disabled="isEmptyValue(currentOrder.uuid) || !IsAllowsPreviewDocument"
+                :disabled="isEmptyValue(currentOrder.uuid) || !IsAllowsPreviewDocument || isLoadingPrintPreview"
+                :loading="isLoadingPrintPreview"
                 :class="isEmptyValue(currentOrder.uuid) || !IsAllowsPreviewDocument ? 'is-disabled-option-card' : 'is-enable-option-card'"
                 style="overflow: hidden; text-overflow: ellipsis; white-space: normal;"
-                @click="printTicketPreviwer()"
+                @click="printPreview()"
               >
                 <i class="el-icon-printer" />
                 <br><br>
@@ -252,7 +251,6 @@
           </el-col>
 
           <!-- createNewReturnOrder -->
-
           <el-col :span="size" style="padding-left: 12px;padding-right: 12px;padding-bottom: 10px;">
             <el-card shadow="hover" style="height: 100px">
               <p
@@ -267,7 +265,6 @@
           </el-col>
 
           <!-- copyOrder -->
-
           <el-col :span="size" style="padding-left: 12px;padding-right: 12px;padding-bottom: 10px;">
             <el-card shadow="hover" style="height: 100px">
               <p
@@ -282,7 +279,6 @@
           </el-col>
 
           <!-- cancelOrder -->
-
           <el-col :span="size" style="padding-left: 12px;padding-right: 12px;padding-bottom: 10px;">
             <el-card shadow="hover" style="height: 100px">
               <p
@@ -298,7 +294,6 @@
           </el-col>
 
           <!-- confirmDelivery -->
-
           <el-col :span="size" style="padding-left: 12px;padding-right: 12px;padding-bottom: 10px;">
             <el-card shadow="hover" style="height: 100px">
               <el-popover
@@ -327,7 +322,6 @@
           </el-col>
 
           <!-- confirmDelivery -->
-
           <el-col :span="size" style="padding-left: 12px;padding-right: 12px;padding-bottom: 10px;">
             <el-card shadow="hover" style="height: 100px">
               <el-popover
@@ -357,7 +351,6 @@
           </el-col>
 
           <!-- applyDiscountOnOrder -->
-
           <el-col v-if="isAllowsApplyDiscount" :span="size" style="padding-left: 12px;padding-right: 12px;padding-bottom: 10px;">
             <el-card shadow="hover" style="height: 100px">
               <el-popover
@@ -402,7 +395,6 @@
           </el-col>
 
           <!-- salesDiscountOff -->
-
           <el-col v-if="isAllowsApplyDiscount" :span="size" style="padding-left: 12px;padding-right: 12px;padding-bottom: 10px;">
             <el-card shadow="hover">
               <el-popover
@@ -693,6 +685,8 @@ export default {
       showSalesDiscount: false,
       visibleReverse: false,
       isLoadingReverse: false,
+      isLoadingPrintPreview: false,
+      isLoadingPrintTicket: false,
       showFieldListOrder: false,
       messageReverseSales: '',
       showConfirmDelivery: false,
@@ -1301,7 +1295,7 @@ export default {
           this.printTicket()
           break
         case this.$t('form.pos.optionsPoinSales.salesOrder.preview'):
-          this.printTicketPreviwer()
+          this.printPreview()
           break
         case this.$t('form.pos.optionsPoinSales.salesOrder.copyOrder'):
           this.copyOrder()
@@ -1338,9 +1332,11 @@ export default {
           break
       }
     },
-    printTicketPreviwer() {
+    printPreview() {
       const orderUuid = this.currentOrder.uuid
       const posUuid = this.currentPointOfSales.uuid
+
+      this.isLoadingPrintPreview = true
       this.$store.dispatch('printTicketPreviwer', { posUuid, orderUuid })
         .then(response => {
           const { processLog } = response
@@ -1392,11 +1388,22 @@ export default {
             showClose: true
           })
         })
+        .finally(() => {
+          this.isLoadingPrintPreview = false
+        })
     },
     printTicket() {
       const orderUuid = this.currentOrder.uuid
       const posUuid = this.currentPointOfSales.uuid
-      this.$store.dispatch('printTicket', { posUuid, orderUuid })
+
+      this.isLoadingPrintTicket = true
+      this.$store.dispatch('printTicket', {
+        posUuid,
+        orderUuid
+      })
+        .finally(() => {
+          this.isLoadingPrintTicket = false
+        })
     },
     generateImmediateInvoice() {
       // TODO: Add BPartner

--- a/components/ADempiere/Form/VPOS/Options/index.vue
+++ b/components/ADempiere/Form/VPOS/Options/index.vue
@@ -221,7 +221,6 @@
                 type="text"
                 :disabled="isEmptyValue(currentOrder.uuid) || !isAllowsPrintDocument || isLoadingPrintTicket"
                 :loading="isLoadingPrintTicket"
-                :class="isEmptyValue(currentOrder.uuid) ? 'is-disabled-option-card' : 'is-enable-option-card'"
                 style="overflow: hidden; text-overflow: ellipsis; white-space: normal;"
                 @click="printTicket()"
               >
@@ -239,7 +238,6 @@
                 type="text"
                 :disabled="isEmptyValue(currentOrder.uuid) || !IsAllowsPreviewDocument || isLoadingPrintPreview"
                 :loading="isLoadingPrintPreview"
-                :class="isEmptyValue(currentOrder.uuid) || !IsAllowsPreviewDocument ? 'is-disabled-option-card' : 'is-enable-option-card'"
                 style="overflow: hidden; text-overflow: ellipsis; white-space: normal;"
                 @click="printPreview()"
               >


### PR DESCRIPTION

https://user-images.githubusercontent.com/20288327/198616352-cc1e0341-309c-4a11-b50e-b97473daf33c.mp4

When a ticket is being printed, the print button remains enabled, if there is a delay either due to internet connection or slow server performance, the user may perceive that it is not printing or that he did not correctly click on the print option.

Now if the request to print has already been sent, until it is not finished either successfully or unsuccessfully, it does not allow to print the ticket again.