### PR TITLE
fix: POS Business Partner fields request.

### DIFF
--- a/components/ADempiere/Form/TimeControl/fieldsList.js
+++ b/components/ADempiere/Form/TimeControl/fieldsList.js
@@ -1,34 +1,34 @@
-// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
-// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
-// Contributor(s): Elsio Sanchez elsiosanches@gmail.com https://github.com/elsiosanchez
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+/**
+ * ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ * Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ * Contributor(s): Elsio Sanchez elsiosanches@gmail.com https://github.com/elsiosanchez
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
 export default [
-  // RecurringType
+  // S_ResourceType_ID
   {
-    fieldUuid: '8cf19da4-fb40-11e8-a479-7a0060f0aa01',
     uuid: '8cf19da4-fb40-11e8-a479-7a0060f0aa01',
     isFromDictionary: true,
     overwriteDefinition: {
       size: 8,
       sequence: 10
-      // name: language.t('timeControl.type')
     }
   },
-  // RecurringType
+  // S_ResourceType_ID Search
   {
-    fieldUuid: '8cf19da4-fb40-11e8-a479-7a0060f0aa01',
+    // TODO: Fix always request when render
     uuid: '8cf19da4-fb40-11e8-a479-7a0060f0aa01',
     elementColumnName: 'RecurringTypeSearch',
     columnName: 'RecurringTypeSearch',

--- a/components/ADempiere/Form/VPOS/BusinessPartner/index.vue
+++ b/components/ADempiere/Form/VPOS/BusinessPartner/index.vue
@@ -35,6 +35,7 @@
             >
               <el-scrollbar wrap-class="scroll-child">
                 <business-partner-create
+                  v-if="popoverCreateBusinessPartner"
                   :parent-metadata="parentMetadata"
                   :show-field="popoverCreateBusinessPartner"
                   :is-visible-address="isVisibleAddress"
@@ -85,15 +86,16 @@
 
           <el-dropdown-item>
             <el-popover
-              v-model="popoverListBusinessParnet"
+              v-model="popoverListBusinessPartner"
               placement="left-start"
               width="900"
               trigger="click"
             >
               <business-partners-list
+                v-if="popoverListBusinessPartner"
                 :parent-metadata="parentMetadata"
-                :shows-popover="popoverListBusinessParnet"
-                :show-field="popoverListBusinessParnet"
+                :shows-popover="popoverListBusinessPartner"
+                :show-field="popoverListBusinessPartner"
                 :is-disabled="isDisabled"
               />
               <el-button
@@ -118,6 +120,7 @@
               style="padding: 0px; margin: 0px"
             >
               <business-partner-update
+                v-if="showUpdate"
                 :shows-popovers="showUpdate"
                 :current-address-select="selectAddress.first_name"
               />
@@ -443,7 +446,7 @@ export default {
         this.$store.commit('popoverCreateBusinessPartner', value)
       }
     },
-    popoverListBusinessParnet: {
+    popoverListBusinessPartner: {
       get() {
         return this.$store.getters.getBusinessPartnerPopoverList
       },
@@ -485,7 +488,7 @@ export default {
   },
 
   watch: {
-    popoverListBusinessParnet(value) {
+    popoverListBusinessPartner(value) {
       if (!value) {
         this.$store.commit('updateValuesOfContainer', {
           containerUuid: 'Business-Partner-List',

--- a/components/ADempiere/Form/VPOS/Options/index.vue
+++ b/components/ADempiere/Form/VPOS/Options/index.vue
@@ -999,11 +999,11 @@ export default {
   },
 
   watch: {
-    whatShowResource(value) {
-      if (!value) {
-        this.isShowResource = value
-      }
-    },
+    // whatShowResource(value) {
+    //   if (!value) {
+    //     this.isShowResource = value
+    //   }
+    // },
     visible(value) {
       if (value && !this.isEmptyValue(this.$refs)) {
         setTimeout(() => {


### PR DESCRIPTION
When you open the point-of-sale form, the fields associated with the business partner listing begin to load, which affects data loading performance, since only those requests should be made when opening the business partner listing.


https://user-images.githubusercontent.com/20288327/198701990-b19d4b82-86c8-44e5-87d1-cd168e459857.mp4

