### PR TITLE
Fix: POS Preview document after `Complete`

### DIFF
--- a/components/ADempiere/Form/VPOS/Collection/index.vue
+++ b/components/ADempiere/Form/VPOS/Collection/index.vue
@@ -261,6 +261,10 @@ import {
 
 // api request methods
 import { processOrder } from '@/api/ADempiere/form/point-of-sales.js'
+import { REPORT_VIEWER_NAME } from '@/utils/ADempiere/constants/report'
+import {
+  buildLinkHref
+} from '@/utils/ADempiere/resource.js'
 
 export default {
   name: 'Collection',
@@ -1284,7 +1288,6 @@ export default {
       })
         .then(response => {
           this.$store.dispatch('printTicket', { posUuid, orderUuid })
-          this.$store.dispatch('printTicketPreviwer', { posUuid, orderUuid })
             .then(() => {
               this.$store.dispatch('setCurrentPOS', this.currentPointOfSales)
                 .then(() => {
@@ -1299,6 +1302,9 @@ export default {
               })
               this.$store.dispatch('reloadOrder', response.uuid)
             })
+          if (this.currentPointOfSales.isAllowsPreviewDocument) {
+            this.printPreview(posUuid, orderUuid)
+          }
           // this.$store.dispatch('reloadOrder', response.uuid)
           this.$message({
             type: 'success',
@@ -1319,6 +1325,59 @@ export default {
           })
           this.$store.dispatch('updateOrderPos', false)
           this.$store.dispatch('updatePaymentPos', false)
+        })
+    },
+    printPreview(posUuid, orderUuid) {
+      this.$store.dispatch('printTicketPreviwer', { posUuid, orderUuid })
+        .then(response => {
+          const { processLog } = response
+          if (!this.isEmptyValue(processLog)) {
+            const link = buildLinkHref({
+              fileName: processLog.output.file_name,
+              outputStream: processLog.output.output_stream,
+              mimeType: processLog.output.mime_type
+            })
+            this.$store.commit('setReportOutput', {
+              download: link.download,
+              format: processLog.output.report_type,
+              fileName: processLog.output.file_name,
+              link,
+              content: processLog.output.output,
+              mimeType: processLog.output.mime_type,
+              name: processLog.output.name,
+              output: processLog.output,
+              outputStream: processLog.output.output_stream,
+              outputStream_asB64: processLog.output.output_stream_asB64,
+              outputStream_asU8: processLog.output.output_stream_asU8,
+              reportType: processLog.output.report_type,
+              reportUuid: processLog.uuid,
+              reportViewUuid: processLog.uuid,
+              tableName: 'C_Order',
+              url: link.href,
+              uuid: processLog.uuid,
+              instanceUuid: processLog.instance_uuid
+            })
+            this.$router.push({
+              name: REPORT_VIEWER_NAME,
+              params: {
+                processId: 110,
+                reportUuid: processLog.uuid,
+                tableName: 'C_Order',
+                menuParentUuid: '',
+                instanceUuid: processLog.instance_uuid,
+                fileName: processLog.output.name,
+                name: processLog.output.name,
+                mimeType: processLog.output.mime_type
+              }
+            }, () => {})
+          }
+        })
+        .catch(error => {
+          this.$message({
+            type: 'error',
+            message: error.message,
+            showClose: true
+          })
         })
     },
     formatDate(date) {

--- a/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/index.vue
+++ b/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/index.vue
@@ -505,6 +505,9 @@ export default {
     }
   },
   computed: {
+    IsAllowsPreviewDocument() {
+      return this.$store.getters.posAttributes.currentPointOfSales.isAllowsPreviewDocument
+    },
     validateOverdrawnInvoice() {
       if (this.option === 1) {
         return this.isEmptyValue(this.listRefund)
@@ -1615,7 +1618,6 @@ export default {
       })
         .then(response => {
           this.$store.dispatch('printTicket', { posUuid, orderUuid })
-          this.$store.dispatch('printTicketPreviwer', { posUuid, orderUuid })
             .then(() => {
               this.$store.dispatch('setCurrentPOS', this.currentPointOfSales)
                 .then(() => {
@@ -1630,6 +1632,9 @@ export default {
               })
               this.$store.dispatch('reloadOrder', response.uuid)
             })
+          if (this.IsAllowsPreviewDocument) {
+            this.$store.dispatch('printTicketPreviwer', { posUuid, orderUuid })
+          }
           this.$message({
             type: 'success',
             message: this.$t('notifications.completed'),

--- a/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/index.vue
+++ b/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/index.vue
@@ -436,7 +436,10 @@ import {
   isReadOnlyField,
   changeFieldShowedFromUser
 } from '@theme/components/ADempiere/Form/VPOS/containerManagerPos.js'
-// import typeRefund from './typeRefund/index.vue'
+import {
+  buildLinkHref
+} from '@/utils/ADempiere/resource.js'
+import { REPORT_VIEWER_NAME } from '@/utils/ADempiere/constants/report'
 
 export default {
   name: 'OverdrawnInvoice',
@@ -1633,7 +1636,7 @@ export default {
               this.$store.dispatch('reloadOrder', response.uuid)
             })
           if (this.IsAllowsPreviewDocument) {
-            this.$store.dispatch('printTicketPreviwer', { posUuid, orderUuid })
+            this.printPreview(posUuid, orderUuid)
           }
           this.$message({
             type: 'success',
@@ -1655,6 +1658,59 @@ export default {
           // })
           this.$store.dispatch('updateOrderPos', false)
           this.$store.dispatch('updatePaymentPos', false)
+        })
+    },
+    printPreview(posUuid, orderUuid) {
+      this.$store.dispatch('printTicketPreviwer', { posUuid, orderUuid })
+        .then(response => {
+          const { processLog } = response
+          if (!this.isEmptyValue(processLog)) {
+            const link = buildLinkHref({
+              fileName: processLog.output.file_name,
+              outputStream: processLog.output.output_stream,
+              mimeType: processLog.output.mime_type
+            })
+            this.$store.commit('setReportOutput', {
+              download: link.download,
+              format: processLog.output.report_type,
+              fileName: processLog.output.file_name,
+              link,
+              content: processLog.output.output,
+              mimeType: processLog.output.mime_type,
+              name: processLog.output.name,
+              output: processLog.output,
+              outputStream: processLog.output.output_stream,
+              outputStream_asB64: processLog.output.output_stream_asB64,
+              outputStream_asU8: processLog.output.output_stream_asU8,
+              reportType: processLog.output.report_type,
+              reportUuid: processLog.uuid,
+              reportViewUuid: processLog.uuid,
+              tableName: 'C_Order',
+              url: link.href,
+              uuid: processLog.uuid,
+              instanceUuid: processLog.instance_uuid
+            })
+            this.$router.push({
+              name: REPORT_VIEWER_NAME,
+              params: {
+                processId: 110,
+                reportUuid: processLog.uuid,
+                tableName: 'C_Order',
+                menuParentUuid: '',
+                instanceUuid: processLog.instance_uuid,
+                fileName: processLog.output.name,
+                name: processLog.output.name,
+                mimeType: processLog.output.mime_type
+              }
+            }, () => {})
+          }
+        })
+        .catch(error => {
+          this.$message({
+            type: 'error',
+            message: error.message,
+            showClose: true
+          })
         })
     },
     findRefundCurrencyConversion(currency) {

--- a/components/ADempiere/Form/VPOS/Options/index.vue
+++ b/components/ADempiere/Form/VPOS/Options/index.vue
@@ -1462,7 +1462,7 @@ export default {
             message: this.$t('notifications.completed'),
             showClose: true
           })
-          this.$store.dispatch('printTicketPreviwer', { posUuid, orderUuid })
+          if (this.IsAllowsPreviewDocument) this.$store.dispatch('printTicketPreviwer', { posUuid, orderUuid })
         })
         .catch(error => {
           this.$message({

--- a/components/ADempiere/Form/VPOS/Options/index.vue
+++ b/components/ADempiere/Form/VPOS/Options/index.vue
@@ -1457,12 +1457,14 @@ export default {
         .then(response => {
           this.$store.dispatch('printTicket', { posUuid, orderUuid })
           this.$store.dispatch('reloadOrder', response.uuid)
+            .then(() => {
+              if (this.IsAllowsPreviewDocument) this.printPreview()
+            })
           this.$message({
             type: 'success',
             message: this.$t('notifications.completed'),
             showClose: true
           })
-          if (this.IsAllowsPreviewDocument) this.$store.dispatch('printTicketPreviwer', { posUuid, orderUuid })
         })
         .catch(error => {
           this.$message({

--- a/components/ADempiere/Form/VPOS/posMixin.js
+++ b/components/ADempiere/Form/VPOS/posMixin.js
@@ -27,6 +27,10 @@ import {
 } from '@/utils/ADempiere/valueFormat.js'
 import orderLineMixin from './Order/orderLineMixin.js'
 import { validatePin } from '@/api/ADempiere/form/point-of-sales.js'
+import {
+  buildLinkHref
+} from '@/utils/ADempiere/resource.js'
+import { REPORT_VIEWER_NAME } from '@/utils/ADempiere/constants/report'
 
 export default {
   name: 'POSMixin',
@@ -451,7 +455,7 @@ export default {
       })
         .then(response => {
           this.$store.dispatch('printTicket', { posUuid, orderUuid })
-          if (this.IsAllowsPreviewDocument) this.$store.dispatch('printTicketPreviwer', { posUuid, orderUuid })
+          if (this.IsAllowsPreviewDocument) this.printPreview(posUuid, orderUuid)
           this.clearOrder()
           this.createOrder({ withLine: false, newOrder: true, customer: this.currentPointOfSales.templateCustomer.uuid })
           this.$store.dispatch('listPayments', { posUuid: this.currentPointOfSales.uuid, orderUuid: this.currentOrder.uuid })
@@ -470,6 +474,59 @@ export default {
           this.$store.dispatch('updateOrderPos', false)
           this.$store.dispatch('updatePaymentPos', false)
           this.$store.commit('dialogoInvoce', { show: false })
+        })
+    },
+    printPreview(posUuid, orderUuid) {
+      this.$store.dispatch('printTicketPreviwer', { posUuid, orderUuid })
+        .then(response => {
+          const { processLog } = response
+          if (!this.isEmptyValue(processLog)) {
+            const link = buildLinkHref({
+              fileName: processLog.output.file_name,
+              outputStream: processLog.output.output_stream,
+              mimeType: processLog.output.mime_type
+            })
+            this.$store.commit('setReportOutput', {
+              download: link.download,
+              format: processLog.output.report_type,
+              fileName: processLog.output.file_name,
+              link,
+              content: processLog.output.output,
+              mimeType: processLog.output.mime_type,
+              name: processLog.output.name,
+              output: processLog.output,
+              outputStream: processLog.output.output_stream,
+              outputStream_asB64: processLog.output.output_stream_asB64,
+              outputStream_asU8: processLog.output.output_stream_asU8,
+              reportType: processLog.output.report_type,
+              reportUuid: processLog.uuid,
+              reportViewUuid: processLog.uuid,
+              tableName: 'C_Order',
+              url: link.href,
+              uuid: processLog.uuid,
+              instanceUuid: processLog.instance_uuid
+            })
+            this.$router.push({
+              name: REPORT_VIEWER_NAME,
+              params: {
+                processId: 110,
+                reportUuid: processLog.uuid,
+                tableName: 'C_Order',
+                menuParentUuid: '',
+                instanceUuid: processLog.instance_uuid,
+                fileName: processLog.output.name,
+                name: processLog.output.name,
+                mimeType: processLog.output.mime_type
+              }
+            }, () => {})
+          }
+        })
+        .catch(error => {
+          this.$message({
+            type: 'error',
+            message: error.message,
+            showClose: true
+          })
         })
     },
     withoutPOSTerminal() {

--- a/components/ADempiere/Form/VPOS/posMixin.js
+++ b/components/ADempiere/Form/VPOS/posMixin.js
@@ -69,6 +69,9 @@ export default {
     }
   },
   computed: {
+    IsAllowsPreviewDocument() {
+      return this.currentPointOfSales.isAllowsPreviewDocument
+    },
     allowsCreateOrder() {
       return this.$store.getters.posAttributes.currentPointOfSales.isAllowsCreateOrder
     },
@@ -448,7 +451,7 @@ export default {
       })
         .then(response => {
           this.$store.dispatch('printTicket', { posUuid, orderUuid })
-          this.$store.dispatch('printTicketPreviwer', { posUuid, orderUuid })
+          if (this.IsAllowsPreviewDocument) this.$store.dispatch('printTicketPreviwer', { posUuid, orderUuid })
           this.clearOrder()
           this.createOrder({ withLine: false, newOrder: true, customer: this.currentPointOfSales.templateCustomer.uuid })
           this.$store.dispatch('listPayments', { posUuid: this.currentPointOfSales.uuid, orderUuid: this.currentOrder.uuid })


### PR DESCRIPTION
### _Bug_

Validate At the Point of Sale. If at the time of order processing you can preview the report after completing

### _GIF_


https://user-images.githubusercontent.com/45974454/202776687-b09db36b-745c-4d4a-8523-e6456b2d68ff.mp4



#### Additional Context
fixes https://github.com/solop-develop/frontend-core/issues/564

