### PR TITLE
Fix: Add Quick option to copy product code

### DIFF
--- a/components/ADempiere/Form/VPOS/ProductInfo/productList.vue
+++ b/components/ADempiere/Form/VPOS/ProductInfo/productList.vue
@@ -289,10 +289,10 @@ export default {
     addSelectProduct(row) {
       this.findProduct(row.product.value)
       this.close()
-      this.$store.commit('showListProductPrice', {
-        attribute: this.popoverName,
-        isShowed: false
-      })
+      // this.$store.commit('showListProductPrice', {
+      //   attribute: this.popoverName,
+      //   isShowed: false
+      // })
     },
     close() {
       this.$store.commit('setShowProductList', false)

--- a/components/ADempiere/Form/VPOS/ProductInfo/productList.vue
+++ b/components/ADempiere/Form/VPOS/ProductInfo/productList.vue
@@ -43,7 +43,7 @@
       height="450"
       highlight-current-row
       @row-click="selectProduct"
-      @row-dblclick="addSelectProduc"
+      @row-dblclick="addSelectProduct"
       @shortkey.native="keyAction"
     >
       <el-table-column
@@ -282,7 +282,7 @@ export default {
     selectProduct(row) {
       this.currentProduct = row
     },
-    addSelectProduc(row) {
+    addSelectProduct(row) {
       this.findProduct(row.product.value)
       this.close()
       this.$store.commit('showListProductPrice', {

--- a/components/ADempiere/Form/VPOS/ProductInfo/productList.vue
+++ b/components/ADempiere/Form/VPOS/ProductInfo/productList.vue
@@ -15,6 +15,7 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https:www.gnu.org/licenses/>.
 -->
+
 <template>
   <el-main
     v-shortkey="shortsKey"
@@ -28,10 +29,11 @@
       @shortkey.native="keyAction"
       @submit.native.prevent="notSubmitForm"
     >
-      <el-form-item label="Código Producto">
+      <el-form-item label="$t('form.productInfo.codeProduct')">
         <el-input v-model="input" :placeholder="$t('quickAccess.searchWithEnter')" @input="searchProduct" />
       </el-form-item>
     </el-form>
+
     <el-table
       ref="listProducto"
       v-shortkey="shortsKey"
@@ -84,12 +86,14 @@
         </template>
       </el-table-column>
     </el-table>
+
     <custom-pagination
       :total="productPrice.recordCount"
       :current-page="productPrice.pageNumber"
       :handle-change-page="handleChangePage"
       :records-page="listWithPrice.length"
     />
+
     <el-row :gutter="24">
       <el-col :span="24">
         <samp style="float: right; padding-right: 10px;">
@@ -116,6 +120,7 @@
 import formMixin from '@theme/components/ADempiere/Form/formMixin.js'
 import CustomPagination from '@theme/components/ADempiere/DataTable/Components/CustomPagination.vue'
 import posMixin from '@theme/components/ADempiere/Form/VPOS/posMixin.js'
+
 // utils and helper methods
 // import fieldsListProductPrice from './fieldsList.js'
 import { formatPrice } from '@/utils/ADempiere/valueFormat.js'

--- a/components/ADempiere/Form/VPOS/ProductInfo/productList.vue
+++ b/components/ADempiere/Form/VPOS/ProductInfo/productList.vue
@@ -46,9 +46,17 @@
       @shortkey.native="keyAction"
     >
       <el-table-column
-        prop="product.value"
         :label="$t('form.productInfo.code')"
-      />
+      >
+        <template slot-scope="scope">
+          <el-button
+            type="text"
+            icon="el-icon-document-copy"
+            @click="copyCode(scope.row)"
+          />
+          {{ scope.row.product.value }}
+        </template>
+      </el-table-column>
       <el-table-column
         prop="product.name"
         :label="$t('form.productInfo.name')"
@@ -108,6 +116,7 @@ import formMixin from '@theme/components/ADempiere/Form/formMixin.js'
 import CustomPagination from '@theme/components/ADempiere/DataTable/Components/CustomPagination.vue'
 // import fieldsListProductPrice from './fieldsList.js'
 import { formatPrice } from '@/utils/ADempiere/valueFormat.js'
+import { copyToClipboard } from '@/utils/ADempiere/coreUtils.js'
 
 export default {
   name: 'ProductList',
@@ -192,6 +201,7 @@ export default {
   },
   methods: {
     formatPrice,
+    copyToClipboard,
     localTableSearch(listWithPrice) {
       let filtersProduct = []
       if (!this.isEmptyValue(this.searchValue) && this.isSearchProduct) {
@@ -311,6 +321,12 @@ export default {
           showClose: true
         })
       }
+    },
+    copyCode(value) {
+      copyToClipboard({
+        text: value.product.value,
+        isShowMessage: true
+      })
     }
   }
 }

--- a/components/ADempiere/Form/VPOS/ProductInfo/productList.vue
+++ b/components/ADempiere/Form/VPOS/ProductInfo/productList.vue
@@ -43,6 +43,7 @@
       height="450"
       highlight-current-row
       @row-click="selectProduct"
+      @row-dblclick="addSelectProduc"
       @shortkey.native="keyAction"
     >
       <el-table-column
@@ -114,7 +115,7 @@
 // components and mixins
 import formMixin from '@theme/components/ADempiere/Form/formMixin.js'
 import CustomPagination from '@theme/components/ADempiere/DataTable/Components/CustomPagination.vue'
-
+import posMixin from '@theme/components/ADempiere/Form/VPOS/posMixin.js'
 // utils and helper methods
 // import fieldsListProductPrice from './fieldsList.js'
 import { formatPrice } from '@/utils/ADempiere/valueFormat.js'
@@ -128,7 +129,8 @@ export default {
   },
 
   mixins: [
-    formMixin
+    formMixin,
+    posMixin
   ],
 
   props: {
@@ -171,11 +173,11 @@ export default {
     currentPointOfSales() {
       return this.$store.getters.posAttributes.currentPointOfSales
     },
-    productPrice() {
+    productListPrice() {
       return this.$store.getters.getProductPrice
     },
     listWithPrice() {
-      const { productPricesList } = this.productPrice
+      const { productPricesList } = this.productListPrice
       if (!this.isEmptyValue(productPricesList)) {
         return productPricesList
       }
@@ -188,7 +190,7 @@ export default {
       }
     },
     isReadyFromGetData() {
-      const { isLoaded, isReload } = this.productPrice
+      const { isLoaded, isReload } = this.productListPrice
       return (!isLoaded || isReload) // && this.isShowProductsPriceList
     },
     searchValue() {
@@ -280,6 +282,14 @@ export default {
     selectProduct(row) {
       this.currentProduct = row
     },
+    addSelectProduc(row) {
+      this.findProduct(row.product.value)
+      this.close()
+      this.$store.commit('showListProductPrice', {
+        attribute: this.popoverName,
+        isShowed: false
+      })
+    },
     close() {
       this.$store.commit('setShowProductList', false)
     },
@@ -287,13 +297,7 @@ export default {
       if (!this.isSelectable) {
         return
       }
-      // TODO: Change this dispatch for set values with local methods, to delete subscripton
-      this.$store.dispatch('notifyActionKeyPerformed', {
-        containerUuid: 'POS',
-        columnName: 'ProductValue',
-        // TODO: Verify with 'value' or 'searchValue' attribute
-        value: this.currentProduct.product.name
-      })
+      this.findProduct(this.currentProduct.product.value)
 
       // close popover of list product price
       this.close()

--- a/components/ADempiere/Form/VPOS/ProductInfo/productList.vue
+++ b/components/ADempiere/Form/VPOS/ProductInfo/productList.vue
@@ -217,7 +217,6 @@ export default {
 
   methods: {
     formatPrice,
-    copyToClipboard,
     localTableSearch(listWithPrice) {
       let filtersProduct = []
       if (!this.isEmptyValue(this.searchValue) && this.isSearchProduct) {
@@ -340,9 +339,9 @@ export default {
         })
       }
     },
-    copyCode(value) {
+    copyCode(row) {
       copyToClipboard({
-        text: value.product.value,
+        text: row.product.value,
         isShowMessage: true
       })
     }

--- a/components/ADempiere/Form/VPOS/ProductInfo/productList.vue
+++ b/components/ADempiere/Form/VPOS/ProductInfo/productList.vue
@@ -114,18 +114,23 @@
 // components and mixins
 import formMixin from '@theme/components/ADempiere/Form/formMixin.js'
 import CustomPagination from '@theme/components/ADempiere/DataTable/Components/CustomPagination.vue'
+
+// utils and helper methods
 // import fieldsListProductPrice from './fieldsList.js'
 import { formatPrice } from '@/utils/ADempiere/valueFormat.js'
 import { copyToClipboard } from '@/utils/ADempiere/coreUtils.js'
 
 export default {
   name: 'ProductList',
+
   components: {
     CustomPagination
   },
+
   mixins: [
     formMixin
   ],
+
   props: {
     metadata: {
       type: Object,
@@ -145,6 +150,7 @@ export default {
       default: 'isShowPopoverField'
     }
   },
+
   data() {
     return {
       defaultMaxPagination: 50,
@@ -157,6 +163,7 @@ export default {
       timeOut: null
     }
   },
+
   computed: {
     isShowProductsPriceList() {
       return this.$store.state['pointOfSales/listProductPrice'].productPrice[this.attribute]
@@ -191,6 +198,7 @@ export default {
       })
     }
   },
+
   created() {
     this.$store.commit('setListProductPrice', {
       isLoaded: false
@@ -199,6 +207,7 @@ export default {
       this.validatePos(this.currentPointOfSales)
     }, 3000)
   },
+
   methods: {
     formatPrice,
     copyToClipboard,


### PR DESCRIPTION
### _**BUGFIX**_

Add Quick option to copy product code. In the product search table

### _**GIF**_

https://user-images.githubusercontent.com/45974454/204012481-94d4abbc-fe9e-4faf-82d9-1534e6b77e77.mp4

**_add Select Produc_**


https://user-images.githubusercontent.com/45974454/204016631-0db262da-2b54-4fc8-b95e-1d594f309a2a.mp4

### _**ISSUES**_

Fixed: [#597](https://github.com/solop-develop/frontend-core/issues/597)