### PR TITLE
feat: Improve field `Posted` to accouting info.

### DIFF
--- a/components/ADempiere/PanelInfo/index.vue
+++ b/components/ADempiere/PanelInfo/index.vue
@@ -402,11 +402,22 @@ export default defineComponent({
 
     const isAccountingInfo = computed(() => {
       const { currentTab } = store.getters.getContainerInfo
+      if (!currentTab.isDocument) {
+        return false
+      }
       const { fieldsList } = currentTab
-      if (isEmptyValue(fieldsList)) return false
-      const isPostedField = fieldsList.find(field => field.columnName === 'Posted')
-      if (isEmptyValue(isPostedField)) return false
-      return isDisplayedField({ ...isPostedField })
+      if (isEmptyValue(fieldsList)) {
+        return false
+      }
+      const isPostedField = fieldsList.find(field => {
+        field.columnName === 'Posted'
+      })
+      if (isEmptyValue(isPostedField)) {
+        return false
+      }
+      return isDisplayedField({
+        ...isPostedField
+      })
     })
 
     /**


### PR DESCRIPTION
improve performance in determining whether accounting information is displayed by adding the evaluation of the `isDocument` flag before searching for the `Posted` field in the field list and evaluating its display.