### PR TITLE
fix: Mobile disable keyboard to filter on `List` reference.

### DIFF
--- a/components/ADempiere/FieldDefinition/FieldSelect.vue
+++ b/components/ADempiere/FieldDefinition/FieldSelect.vue
@@ -21,7 +21,7 @@
     :key="componentKey"
     v-model="value"
     v-bind="commonsProperties"
-    :filterable="true"
+    :filterable="isFiltrable"
     :loading="isLoading"
     value-key="value"
     clearable
@@ -48,6 +48,9 @@
 import fieldMixin from '@theme/components/ADempiere/FieldDefinition/mixin/mixinField.js'
 import fieldWithDisplayColumn from '@theme/components/ADempiere/FieldDefinition/mixin/mixinWithDisplayColumn.js'
 import selectMixin from '@theme/components/ADempiere/FieldDefinition/mixin/mixinFieldSelect.js'
+
+// Constants
+import { LIST } from '@/utils/ADempiere/references'
 
 // Utils and Helper Methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
@@ -83,6 +86,15 @@ export default {
         styleClass += ' custom-field-select-multiple '
       }
       return styleClass
+    },
+
+    isFiltrable() {
+      if (this.isMobile) {
+        if (LIST.id === this.metadata.displayType) {
+          return false
+        }
+      }
+      return true
     },
 
     isWithSearchValue() {


### PR DESCRIPTION
When it is a drop-down field of reference `List`, the keyboard appears to filter data in the mobile, but it makes the handling a bit cumbersome, it is disabled considering that this type of fields handle few records in the number of elements.

### Before this changes

![imagen](https://github.com/solop-develop/frontend-default-theme/assets/20288327/b3bd7a05-dcb6-4948-815a-d842d8490bd0)


### After this changes

![imagen](https://github.com/solop-develop/frontend-default-theme/assets/20288327/5cbe88d0-e154-4b47-9a4d-cc2ccc0a69bd)


### Additional context
On `Table` and `Table Direct` is still enabled the keyboard to filter.
![imagen](https://github.com/solop-develop/frontend-default-theme/assets/20288327/1559f62b-7105-4877-b06c-e87be7613dfd)

fixes https://github.com/solop-develop/frontend-core/issues/1152
