### PR TITLE
fix: Mobile field tittle space and crop width name.

### DIFF
--- a/components/ADempiere/FieldDefinition/FieldOptions/LabelField.vue
+++ b/components/ADempiere/FieldDefinition/FieldOptions/LabelField.vue
@@ -1,10 +1,29 @@
+<!--
+ ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ Copyright (C) 2018-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ Contributor(s): Leonel Matos lmatos@erpya.com
+ Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https:www.gnu.org/licenses/>.
+-->
+
 <template>
   <div v-if="!isFieldOnly" :style="labelStyle" class="label-field">
-    <span>
+    <span class="field-title-name">
       {{ label }}
     </span>
 
-    <span v-if="isMandatory" :style="'color: #f34b4b'"> * </span>
+    <span v-if="isMandatory" style="color: #f34b4b"> * </span>
 
     <i :class="cssClassName" :style="iconStyle" />
   </div>
@@ -82,6 +101,13 @@ export default defineComponent({
 </style>
 <style lang="scss" scoped>
 .label-field {
+  .field-title-name {
+    color: #909399 !important;
+    &:hover {
+      color: #303133 !important;
+    }
+  }
+
   .el-icon-info {
     font-size: 11px;
     color: #008fd3;

--- a/components/ADempiere/FieldDefinition/FieldOptions/index.vue
+++ b/components/ADempiere/FieldDefinition/FieldOptions/index.vue
@@ -1,6 +1,6 @@
 <!--
  ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
- Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ Copyright (C) 2018-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
  Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@
       size="mini"
       hide-on-click
       trigger="click"
-      :style="'text-overflow: ellipsis; white-space: nowrap; overflow: hidden; width:' + labelStyle + '%'"
+      :style="'text-overflow: ellipsis; white-space: nowrap; overflow: hidden; width: 100%'"
       @command="handleCommand"
       @click="false"
     >
@@ -239,7 +239,7 @@ export default defineComponent({
       } else if (props.metadata.name.length >= 20) {
         return '50'
       }
-      return '110'
+      return '100'
     })
 
     /**
@@ -467,6 +467,8 @@ export default defineComponent({
 
 <style lang="scss">
 .field-options {
+  max-height: 30px !important;
+
   &.el-menu--horizontal,
   .el-menu--horizontal {
     // transparent background color of the field label

--- a/components/ADempiere/FieldDefinition/index.vue
+++ b/components/ADempiere/FieldDefinition/index.vue
@@ -418,6 +418,15 @@ export default {
 </script>
 
 <style lang="scss">
+.field-definition-mobile {
+  /**
+   * Reduce the spacing between the form element and its label
+   */
+   .el-form-item__label {
+    padding-bottom: 0px !important;
+  }
+}
+
 .field-definition {
   /**
    * Separation between elements (item) of the form


### PR DESCRIPTION
After this changes

![imagen](https://github.com/solop-develop/frontend-default-theme/assets/20288327/57d09c57-e6d1-400e-afa7-104c58c56dde)


Before this changes

![imagen](https://github.com/solop-develop/frontend-default-theme/assets/20288327/0b3fa3e1-d4d4-4dd4-96fc-ab59ec11a6a3)


fixes https://github.com/solop-develop/frontend-core/issues/1153