### PR TITLE
fix: Smart Browser, `IN` or `NOT IN` operator with multiple values.

### DIFF
--- a/components/ADempiere/FieldDefinition/FieldOptions/ComparisonOperator.vue
+++ b/components/ADempiere/FieldDefinition/FieldOptions/ComparisonOperator.vue
@@ -61,6 +61,10 @@ export default defineComponent({
     metadataField: {
       type: Object,
       default: () => ({})
+    },
+    containerManager: {
+      type: Object,
+      default: () => ({})
     }
   },
 
@@ -91,7 +95,8 @@ export default defineComponent({
     function handleOperator(operator) {
       const {
         columnName,
-        containerUuid
+        containerUuid,
+        parentUuid
       } = props.metadataField
       store.commit('updateValueOfField', {
         containerUuid,
@@ -104,6 +109,15 @@ export default defineComponent({
         attributeName: 'operator',
         attributeValue: operator,
         field: props.metadataField
+      })
+
+      store.dispatch('notifyFieldChange', {
+        parentUuid,
+        containerUuid,
+        containerManager: props.containerManager,
+        field: props.metadataField,
+        columnName,
+        newValue: undefined
       })
     }
 

--- a/components/ADempiere/FieldDefinition/FieldSelect.vue
+++ b/components/ADempiere/FieldDefinition/FieldSelect.vue
@@ -296,7 +296,7 @@ export default {
     // https://github.com/ElemeFE/element/issues/21287
     // https://github.com/ElemeFE/element/issues/21465
     getValueOfLookup() {
-      if (this.metadata.isAdvancedQuery && this.isSelectMultiple) {
+      if (this.isSelectMultiple) {
         return
       }
       this.isLoading = true

--- a/components/ADempiere/FieldDefinition/index.vue
+++ b/components/ADempiere/FieldDefinition/index.vue
@@ -67,6 +67,7 @@
           />
           <comparison-operator
             :metadata-field="field"
+            :container-manager="containerManager"
             :style="styleOperator"
           />
         </div>


### PR DESCRIPTION
#### Before this changes

https://github.com/solop-develop/frontend-default-theme/assets/20288327/76835db7-9093-4bbc-9d57-89a61c2c18c6


#### After this changes

https://github.com/solop-develop/frontend-default-theme/assets/20288327/f038c36d-b033-42b7-b833-ddc23d829e1d


fixes https://github.com/solop-develop/frontend-core/issues/1164
