### PR TITLE
Fix: The labels are being displayed on the buttons in the option to delete registration

### DIFF
--- a/components/ADempiere/TabManager/convenienceButtons/DeleteRecordButton.vue
+++ b/components/ADempiere/TabManager/convenienceButtons/DeleteRecordButton.vue
@@ -38,18 +38,21 @@
       </el-descriptions-item>
     </el-descriptions>
 
-    <div style="text-align: right; margin: 0">
-      <el-button size="mini" type="text" @click="isVisibleConfirmDelete = false">
-        {{ $t('window.cancel') }}
-      </el-button>
+    <div
+      style="text-align: right; margin: 0;margin-top: 5px;"
+    >
       <el-button
-        ref="buttonConfirmDelete"
+        type="danger"
+        class="button-base-icon"
+        icon="el-icon-close"
+        @click="isVisibleConfirmDelete = false"
+      />
+      <el-button
         type="primary"
-        size="mini"
+        class="button-base-icon"
+        icon="el-icon-check"
         @click="deleteCurrentRecord()"
-      >
-        {{ $t('window.confirm') }}
-      </el-button>
+      />
     </div>
 
     <el-button


### PR DESCRIPTION
  ## **_Bug report / Feature_**
  Fix: The labels are being displayed on the buttons in the option to delete registration  
  - [x] Labels on buttons are being displayed
  
  ### **_Screenshot or Gif_**
  ![image](https://github.com/solop-develop/frontend-default-theme/assets/45974454/9666bc6a-b848-4be1-937f-eec20de439a1)

### **_Issues_**

Fixed: https://github.com/solop-develop/frontend-core/issues/1147