### PR TITLE
Fix: Movil, menu de acciones, maximo 5 acciones y mas opciones en el drawer

### DIFF
--- a/components/ADempiere/ActionMenu/common-style.scss
+++ b/components/ADempiere/ActionMenu/common-style.scss
@@ -65,7 +65,7 @@
     margin-right: 3px;
 
     &:last-child {
-      margin-right: 10px;
+      margin-right: 5px;
     }
   }
 }

--- a/components/ADempiere/ActionMenu/menuMobile.vue
+++ b/components/ADempiere/ActionMenu/menuMobile.vue
@@ -18,57 +18,57 @@ along with this program. If not, see <https:www.gnu.org/licenses/>.
 
 <template>
   <div :class="isClassOptions">
-    <!-- actions or process on container -->
-    <el-dropdown
-      v-if="!isEmptyValue(actionsManager)"
-      :hide-on-click="true"
-      :size="size"
-      :split-button="isWithDefaultAction"
-      type="primary"
-      trigger="click"
-      :class="{ 'action-container': true, 'without-defualt-action': !isWithDefaultAction }"
-      @command="runAction"
-      @click="runDefaultAction"
+    <el-menu
+      default-active="2"
+      class="el-menu-vertical-demo"
+      style="display: block;width: -webkit-fill-available;"
+      @select="runAction"
     >
-      <template v-if="isWithDefaultAction">
-        {{ defaultActionName }}
-      </template>
-      <el-button v-else type="primary" plain :size="size">
-        <svg-icon icon-class="more-vertical" />
-      </el-button>
-
-      <el-dropdown-menu slot="dropdown" class="action-dropdown-menu">
-        <el-dropdown-item
-          v-if="isEmptyValue(actionsList)"
-          key="withoutActions"
-          style="min-height: 26px"
-        >
-          <span class="contents">
-            <b class="label">
-              {{ $t('actionMenu.withoutActions') }}
-            </b>
-          </span>
-        </el-dropdown-item>
-
-        <el-scrollbar v-else key="withActions" wrap-class="scroll-child">
-          <el-dropdown-item
-            v-for="(action, index) in actionsList"
-            v-show="!action.displayed || (action.displayed && action.displayed({
-              parentUuid,
-              containerUuid
-            }))"
+      <span
+        v-for="(action, index) in actionsList"
+        :key="index"
+      >
+        <span v-if="isEmptyValue(action.childs)">
+          <el-menu-item
             :key="index"
-            :command="action"
+            :index="action.actionName"
             :disabled="!action.enabled({
               root: $root,
               parentUuid,
               containerUuid,
               containerManager
             })"
-            :divided="true"
           >
-            <div class="contents">
-              <div class="auxiliary-menu-icon">
+            <b>
+              <svg-icon
+                v-if="action.isSvgIcon || action.svg === true"
+                :icon-class="action.icon"
+                style="font-size: 18"
+              />
+              <i
+                v-else
+                :class="action.icon"
+                style="font-size: 18"
+              />
+            </b>
+            <b class="label">
+              {{ action.name }}
+            </b>
+          </el-menu-item>
+        </span>
+        <span v-else>
+          <el-submenu
+            :index="action.actionName"
+            style="padding-left: 20px;"
+            :disabled="!action.enabled({
+              root: $root,
+              parentUuid,
+              containerUuid,
+              containerManager
+            })"
+          >
+            <template slot="title">
+              <b>
                 <svg-icon
                   v-if="action.isSvgIcon || action.svg === true"
                   :icon-class="action.icon"
@@ -79,79 +79,37 @@ along with this program. If not, see <https:www.gnu.org/licenses/>.
                   :class="action.icon"
                   style="font-size: 18"
                 />
-              </div>
-
-              <!-- for print format -->
-              <el-dropdown v-if="!isEmptyValue(action.childs)">
-                <span>
-                  <b class="label">
-                    {{ action.name }}
-                  </b>
-                  <i class="el-icon-arrow-down" style="float: right;" />
-                  <p class="description">
-                    <template v-if="isEmptyValue(action.description)">
-                      {{ $t('data.noDescription') }}
-                    </template>
-                    <template v-else>
-                      {{ action.description }}
-                    </template>
-                  </p>
-                </span>
-
-                <el-dropdown-menu
-                  slot="dropdown"
-                  @command="runAction"
-                >
-                  <el-scrollbar wrap-class="scroll-child">
-                    <el-dropdown-item
-                      v-for="(actionChild, key) in action.childs"
-                      :key="key"
-                      :command="actionChild"
-                      :divided="true"
-                    >
-                      <div @click="runAction(actionChild)">
-                        <span class="contents">
-                          <b class="label">
-                            {{ actionChild.name }}
-                          </b>
-                        </span>
-
-                        <p class="description">
-                          <template v-if="isEmptyValue(actionChild.description)">
-                            {{ $t('data.noDescription') }}
-                          </template>
-                          <template v-else>
-                            {{ actionChild.description }}
-                          </template>
-                        </p>
-                      </div>
-                    </el-dropdown-item>
-                  </el-scrollbar>
-                </el-dropdown-menu>
-              </el-dropdown>
-
-              <div v-else>
-                <span class="contents">
-                  <b class="label">
-                    {{ action.name }}
-                  </b>
-                </span>
-
-                <p class="description">
-                  <template v-if="isEmptyValue(action.description)">
-                    {{ $t('data.noDescription') }}
-                  </template>
-                  <template v-else>
-                    {{ action.description }}
-                  </template>
-                </p>
-                <br v-if="indexSpace(index, actionsList.length)">
-              </div>
-            </div>
-          </el-dropdown-item>
-        </el-scrollbar>
-      </el-dropdown-menu>
-    </el-dropdown>
+              </b>
+              <b class="label">
+                {{ action.name }}
+              </b>
+            </template>
+            <el-menu-item
+              v-for="(actionChild, key) in action.childs"
+              :key="key"
+              :index="action.actionName"
+              style="padding-left: 15px;"
+            >
+              <b>
+                <svg-icon
+                  v-if="actionChild.isSvgIcon || actionChild.svg === true"
+                  :icon-class="actionChild.icon"
+                  style="font-size: 18"
+                />
+                <i
+                  v-else
+                  :class="actionChild.icon"
+                  style="font-size: 18"
+                />
+              </b>
+              <b class="label">
+                {{ actionChild.name }}
+              </b>
+            </el-menu-item>
+          </el-submenu>
+        </span>
+      </span>
+    </el-menu>
   </div>
 </template>
 
@@ -165,7 +123,7 @@ import store from '@/store'
 import { isEmptyValue, getTypeOfValue } from '@/utils/ADempiere/valueUtils'
 
 export default defineComponent({
-  name: 'MenuActions',
+  name: 'menuMobile',
 
   props: {
     parentUuid: {
@@ -188,11 +146,14 @@ export default defineComponent({
   },
 
   setup(props, { root }) {
+    const currentTab = computed(() => {
+      return store.getters.getContainerInfo.currentTab
+    })
+
     const {
-      parentUuid,
       containerUuid,
       tableName
-    } = props.actionsManager
+    } = currentTab.value
 
     const isMobile = computed(() => {
       return store.getters.device === 'mobile'
@@ -278,21 +239,24 @@ export default defineComponent({
      * @param {object} action
      */
     function runAction(action) {
-      const { actionName } = action
-      action[actionName]({
+      const currentAction = actionsList.value.find(list => list.actionName === action)
+      const { actionName } = currentAction
+      currentAction[actionName]({
         root,
-        parentUuid,
-        containerUuid,
-        tableName,
+        parentUuid: currentTab.value.parentUuid,
+        containerUuid: currentTab.value.containerUuid,
+        tableName: currentTab.value.tableName,
         instanceUuid,
         containerManager: props.containerManager,
         recordUuid: recordUuid.value,
-        uuid: action.uuid
+        uuid: action.uuid,
+        currentTab: currentTab.value
       })
+      store.commit('setShowMenuMobile', false)
     }
 
     /**
-     * Index Space
+     * Index SpactabAttributese
      */
 
     function indexSpace(index, menuList) {
@@ -300,7 +264,10 @@ export default defineComponent({
     }
 
     return {
+      currentTab,
+      //
       size,
+      isMobile,
       actionsList,
       isClassOptions,
       defaultActionName,

--- a/components/ADempiere/FilterFields/fieldsDisplayOptions.vue
+++ b/components/ADempiere/FilterFields/fieldsDisplayOptions.vue
@@ -19,7 +19,7 @@
 <template>
   <span>
     <!-- Show Options -->
-    <el-dropdown trigger="click" class="fields-display-options" size="small" @command="handleCommand">
+    <el-dropdown trigger="click" class="fields-display-options" @command="handleCommand">
       <span class="el-dropdown-link">
         <svg-icon icon-class="list" />
       </span>
@@ -684,5 +684,6 @@ export default defineComponent({
 <style scoped lang="scss">
   .fields-display-options {
     padding-left: 5px;
+    font-size: 16px;
   }
 </style>

--- a/components/ADempiere/FilterFields/index.vue
+++ b/components/ADempiere/FilterFields/index.vue
@@ -420,7 +420,8 @@ export default defineComponent({
 }
 .right-panel-field-options-table {
   position: absolute;
-  right: 0%;
+  right: 8px;
+  margin-top: 5px;
   display: block;
 }
 .right-panel-field-options {

--- a/components/ADempiere/TabManager/AdvancedTabQuery.vue
+++ b/components/ADempiere/TabManager/AdvancedTabQuery.vue
@@ -179,9 +179,9 @@ export default defineComponent({
 
     const styleIconSvg = computed(() => {
       if (isShowedTableRecords.value) {
-        return 'position: absolute;right: 51px;display: inline-block;padding-right: 10px;float: right;width: 300px;'
+        return 'position: absolute;right: 66px;display: inline-block;padding-right: 5px;float: right;width: 293px;'
       }
-      return 'position: absolute;right: 68px;display: inline-block;padding-right: 0px;float: right;margin-top: 2px;width: 290px;'
+      return 'position: absolute;right: 70px;display: inline-block;padding-right: 0px;float: right;width: 289px;margin-top: -1px;'
     })
 
     const containerManagerAdvancedQuery = computed(() => {

--- a/components/ADempiere/TabManager/TabOptions.vue
+++ b/components/ADempiere/TabManager/TabOptions.vue
@@ -48,19 +48,37 @@
       style="display: contents;"
     />
 
-    <full-screen-container
+    <!-- <full-screen-container
       style="float: right;"
       :parent-uuid="parentUuid"
       :container-uuid="currentTabUuid"
-    />
+    /> -->
 
     <action-menu
       :parent-uuid="parentUuid"
-      :container-uuid="currentTabUuid"
+      :container-uuid="$store.getters.getContainerInfo.currentTab.containerUuid"
       :container-manager="containerManager"
       :actions-manager="listAction"
       style="float: right;"
     />
+    <el-drawer
+      :visible.sync="showMenuMobile"
+      :with-header="true"
+      size="100%"
+      class="drawer-panel-info"
+    >
+      <span slot="title">
+        <span style="color: #606266; font-weight: bold;">
+          {{ $t('actionMenu.menu') }} {{ $store.getters.getContainerInfo.currentTab.name }}
+        </span>
+      </span>
+      <menu-mobile
+        :parent-uuid="parentUuid"
+        :container-uuid="$store.getters.getContainerInfo.currentTab.containerUuid"
+        :container-manager="containerManager"
+        :actions-manager="listAction"
+      />
+    </el-drawer>
   </div>
 </template>
 
@@ -72,9 +90,12 @@ import store from '@/store'
 
 // Components and Mixins
 import ActionMenu from '@theme/components/ADempiere/ActionMenu/index.vue'
+import menuMobile from '@theme/components/ADempiere/ActionMenu/menuMobile.vue'
 import ConvenienceButtons from '@theme/components/ADempiere/TabManager/convenienceButtons/index.vue'
-import FullScreenContainer from '@theme/components/ADempiere/ContainerOptions/FullScreenContainer'
+// import FullScreenContainer from '@theme/components/ADempiere/ContainerOptions/FullScreenContainer'
 import ChangeRecord from '@theme/components/ADempiere/DataTable/Components/ChangeRecord.vue'
+// Utils and Helper Methods
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
 
 export default defineComponent({
   name: 'TabOptions',
@@ -82,8 +103,9 @@ export default defineComponent({
   components: {
     ActionMenu,
     ConvenienceButtons,
-    FullScreenContainer,
-    ChangeRecord
+    // FullScreenContainer,
+    ChangeRecord,
+    menuMobile
   },
 
   props: {
@@ -128,15 +150,16 @@ export default defineComponent({
 
   setup(props) {
     const listAction = computed(() => {
+      const tab = store.getters.getContainerInfo.currentTab
       return {
         parentUuid: props.parentUuid,
-        containerUuid: props.tabAttributes.uuid,
+        containerUuid: isEmptyValue(tab) ? props.tabAttributes.uuid : tab.containerUuid,
         defaultActionName: language.t('actionMenu.createNewRecord'),
-        tableName: props.tabAttributes.tableName,
+        tableName: isEmptyValue(tab) ? props.tabAttributes.tableName : tab.tableName,
         withoutDefaulAction: true,
         getActionList: () => {
           return store.getters.getStoredActionsMenu({
-            containerUuid: props.tabAttributes.uuid
+            containerUuid: isEmptyValue(tab) ? props.tabAttributes.uuid : tab.containerUuid
           })
         }
       }
@@ -162,6 +185,17 @@ export default defineComponent({
         return language.t('window.toggleSingle')
       }
       return language.t('window.multiRecord')
+    })
+
+    const showMenuMobile = computed({
+      // getter
+      get() {
+        return store.getters.getShowMenuMobile
+      },
+      // setter
+      set(newValue) {
+        store.commit('setShowMenuMobile', newValue)
+      }
     })
 
     function changeShowedRecords() {
@@ -196,10 +230,11 @@ export default defineComponent({
 
     return {
       // computed
+      label,
       isMobile,
       listAction,
       isShowedTableRecords,
-      label,
+      showMenuMobile,
       // methods
       changeShowedRecords
     }

--- a/components/ADempiere/TabManager/TabPanel/modeDesktop.vue
+++ b/components/ADempiere/TabManager/TabPanel/modeDesktop.vue
@@ -218,7 +218,7 @@ export default defineComponent({
         return 'height: 78px'
       }
       // mono record
-      return 'height: 39px'
+      return 'height: 40px'
     })
 
     const styleFooterPanel = computed(() => {
@@ -480,7 +480,7 @@ export default defineComponent({
 
 <style>
 .el-tabs--border-card > .el-tabs__content {
-  padding: 15px;
+  /* padding: 15px; */
   overflow: auto;
   height: 92%;
   padding-top: 5px;

--- a/components/ADempiere/TabManager/index.vue
+++ b/components/ADempiere/TabManager/index.vue
@@ -269,9 +269,9 @@ export default defineComponent({
 
     const sizeBadgeRight = computed(() => {
       if (isMobile.value) {
-        return 'width: 5%;height: 100%;position: fixed;right: 5%;top: 45%;z-index: 9;'
+        return 'width: 0%;height: 100%;position: absolute;right: 10%;top: 45%;z-index: 9;'
       }
-      return 'width: 1%;height: 100%;position: fixed;right: 1%;top: 45%;z-index: 9;'
+      return 'width: 0%;height: 100%;position: absolute;right: 2%;top: 45%;z-index: 9;'
     })
 
     const tabStyle = computed(() => {


### PR DESCRIPTION
  ## **_Bug report / Feature_**
  Fix: Movil, menu de acciones, maximo 5 acciones y mas opciones en el drawer
  - [x] Movil, menu de acciones, maximo 5 acciones y mas opciones en el drawer
  
  ### **_Screenshot or Gif_**


https://github.com/solop-develop/frontend-default-theme/assets/45974454/94b17a95-b299-4366-ab7e-68ca390f35d4

### **_Issues_**

Fixed: https://github.com/solop-develop/frontend-core/issues/1151

