### PR TITLE
fix: Get attachment before upload resource.

### DIFF
--- a/components/ADempiere/PanelInfo/Component/AttachmentManager/uploadResource.vue
+++ b/components/ADempiere/PanelInfo/Component/AttachmentManager/uploadResource.vue
@@ -1,6 +1,6 @@
 <!--
  ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
- Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
+ Copyright (C) 2018-Present E.R.P. Consultores y Asociados, C.A. www.erpya.com
  Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com https://github.com/EdwinBetanc0urt
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -9,7 +9,7 @@
 
  This program is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
@@ -109,7 +109,7 @@ export default defineComponent({
           fileSize: file.size
         }).then(response => {
           additionalData.value = {
-            resource_uuid: response.resource_uuid,
+            resource_uuid: response.uuid,
             file_name: response.file_name
           }
           // filesList.value.push(file)
@@ -121,11 +121,11 @@ export default defineComponent({
           })
           reject(false)
         }).finally(() => {
-          store.dispatch('findAttachment', {
-            tableName: props.tableName,
-            recordId: props.recordId,
-            recordUuid: props.recordUuid
-          })
+          // store.dispatch('findAttachment', {
+          //   tableName: props.tableName,
+          //   recordId: props.recordId,
+          //   recordUuid: props.recordUuid
+          // })
           // upload.value.uploadFiles = filesList.value
         })
       })
@@ -133,6 +133,12 @@ export default defineComponent({
 
     function loadedSucess(response, file, fileList) {
       additionalData.value = {}
+
+      store.dispatch('findAttachment', {
+        tableName: props.tableName,
+        recordId: props.recordId,
+        recordUuid: props.recordUuid
+      })
     }
 
     return {


### PR DESCRIPTION
When the resource reference is created, the attachment is consulted, but if the file has not yet been fully uploaded and the size of the reference is zero, the attachment should be consulted only after the resource is fully uploaded.