### PR TITLE
fix: Validate upload attachment request.

### DIFF
--- a/components/ADempiere/PanelInfo/Component/AttachmentManager/uploadResource.vue
+++ b/components/ADempiere/PanelInfo/Component/AttachmentManager/uploadResource.vue
@@ -141,10 +141,10 @@ export default defineComponent({
     }
 
     function handleError(error, file, fileList) {
-        return showMessage({
-          type: 'error',
-          message: error.message || lang.t('component.attachment.error')
-        })
+      return showMessage({
+        type: 'error',
+        message: error.message || lang.t('component.attachment.error')
+      })
     }
 
     function loadedSucess(response, file, fileList) {


### PR DESCRIPTION
Validates that if creating the resource reference generates an error, do not execute the file upload.

The responses are also handled since they may have 400 or 500 codes from the server and the upload of the file is executed when it should be managed as an error


fixes https://github.com/solop-develop/frontend-core/issues/583