### PR TITLE
fix: Center `Image Field` with table records.

### DIFF
--- a/components/ADempiere/DataTable/Components/CellDisplayInfo.vue
+++ b/components/ADempiere/DataTable/Components/CellDisplayInfo.vue
@@ -193,9 +193,9 @@ export default defineComponent({
     const cellCssClass = computed(() => {
       let classCss = ''
       if (props.fieldAttributes.componentPath === 'FieldNumber') {
-        classCss += ' cell-align-right '
+        classCss = ' cell-align-right '
       }
-      if (props.fieldAttributes.isColumnDocumentStatus) {
+      if (props.fieldAttributes.isColumnDocumentStatus || props.fieldAttributes.displayType === IMAGE.id) {
         classCss = ' cell-align-center '
       }
       return classCss


### PR DESCRIPTION
#### Before this changes

![image](https://github.com/solop-develop/frontend-default-theme/assets/20288327/8628c120-a471-4fd6-b798-ff02d770356e)


#### After this changes

![image](https://github.com/solop-develop/frontend-default-theme/assets/20288327/b347be98-474c-4965-a46f-f3c9e990ceac)


#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/1254